### PR TITLE
Cell by row/column filtering API with worksheetCache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,9 +112,9 @@ DerivedData/
 !default.perspectivev3
 
 ### Xcode Patch ###
-*.xcodeproj/*
-!*.xcodeproj/project.pbxproj
-!*.xcodeproj/xcshareddata/
+# *.xcodeproj/*
+# !*.xcodeproj/project.pbxproj
+# !*.xcodeproj/xcshareddata/
 !*.xcworkspace/contents.xcworkspacedata
 /*.gcno
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ before_install:
 # - pod install --project-directory=Example
 script:
 - pod lib lint
-- swift package update
+- swift package generate-xcodeproj --xcconfig-overrides Package.xcconfig
+- git checkout HEAD CoreXLSX.xcodeproj/xcshareddata/xcschemes/CoreXLSX-Package.xcscheme
 - xcodebuild test -enableCodeCoverage YES -scheme CoreXLSX-Package
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 # - pod install --project-directory=Example
 script:
 - pod lib lint
+- swift build
 - xcodebuild test -enableCodeCoverage YES -scheme CoreXLSX-Package
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 # - pod install --project-directory=Example
 script:
 - pod lib lint
-- swift build
+- swift package update
 - xcodebuild test -enableCodeCoverage YES -scheme CoreXLSX-Package
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ before_install:
 # - pod install --project-directory=Example
 script:
 - pod lib lint
+after_success:
+- bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ before_install:
 # - pod install --project-directory=Example
 script:
 - pod lib lint
+- xcodebuild test -enableCodeCoverage YES -scheme CoreXLSX-Package
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/CoreXLSX.xcodeproj/CoreXLSXTests_Info.plist
+++ b/CoreXLSX.xcodeproj/CoreXLSXTests_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/CoreXLSX.xcodeproj/CoreXLSX_Info.plist
+++ b/CoreXLSX.xcodeproj/CoreXLSX_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/CoreXLSX.xcodeproj/XMLCoder_Info.plist
+++ b/CoreXLSX.xcodeproj/XMLCoder_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/CoreXLSX.xcodeproj/XMLParsing_Info.plist
+++ b/CoreXLSX.xcodeproj/XMLParsing_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/CoreXLSX.xcodeproj/ZIPFoundation_Info.plist
+++ b/CoreXLSX.xcodeproj/ZIPFoundation_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/CoreXLSX.xcodeproj/project.pbxproj
+++ b/CoreXLSX.xcodeproj/project.pbxproj
@@ -3,17 +3,17 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
 		"CoreXLSX::CoreXLSXPackageTests::ProductTarget" /* CoreXLSXPackageTests */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = OBJ_70 /* Build configuration list for PBXAggregateTarget "CoreXLSXPackageTests" */;
+			buildConfigurationList = OBJ_72 /* Build configuration list for PBXAggregateTarget "CoreXLSXPackageTests" */;
 			buildPhases = (
 			);
 			dependencies = (
-				OBJ_73 /* PBXTargetDependency */,
+				OBJ_75 /* PBXTargetDependency */,
 			);
 			name = CoreXLSXPackageTests;
 			productName = CoreXLSXPackageTests;
@@ -21,77 +21,77 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		D11B79B22189BD62005AF0C6 /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D11B79B12189BD62005AF0C6 /* Worksheet.swift */; };
-		OBJ_100 /* XMLReferencingEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* XMLReferencingEncoder.swift */; };
-		OBJ_101 /* ISO8601DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* ISO8601DateFormatter.swift */; };
-		OBJ_102 /* XMLKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* XMLKey.swift */; };
-		OBJ_103 /* XMLStackParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* XMLStackParser.swift */; };
-		OBJ_110 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* Package.swift */; };
-		OBJ_115 /* Archive+Reading.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* Archive+Reading.swift */; };
-		OBJ_116 /* Archive+Writing.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* Archive+Writing.swift */; };
-		OBJ_117 /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* Archive.swift */; };
-		OBJ_118 /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* Data+Compression.swift */; };
-		OBJ_119 /* Data+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* Data+Serialization.swift */; };
-		OBJ_120 /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* Entry.swift */; };
-		OBJ_121 /* FileManager+ZIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* FileManager+ZIP.swift */; };
-		OBJ_128 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* Package.swift */; };
-		OBJ_54 /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* CoreXLSX.swift */; };
-		OBJ_55 /* Relationships.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Relationships.swift */; };
-		OBJ_57 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */; };
-		OBJ_58 /* XMLParsing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XMLParsing::XMLParsing::Product" /* XMLParsing.framework */; };
-		OBJ_68 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
-		OBJ_79 /* CoreXLSXTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* CoreXLSXTests.swift */; };
-		OBJ_80 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* XCTestManifests.swift */; };
-		OBJ_82 /* CoreXLSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */; };
-		OBJ_83 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */; };
-		OBJ_84 /* XMLParsing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XMLParsing::XMLParsing::Product" /* XMLParsing.framework */; };
-		OBJ_92 /* DecodingErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_30 /* DecodingErrorExtension.swift */; };
-		OBJ_93 /* XMLDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* XMLDecoder.swift */; };
-		OBJ_94 /* XMLDecodingStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* XMLDecodingStorage.swift */; };
-		OBJ_95 /* XMLKeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* XMLKeyedDecodingContainer.swift */; };
-		OBJ_96 /* XMLUnkeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* XMLUnkeyedDecodingContainer.swift */; };
-		OBJ_97 /* EncodingErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_36 /* EncodingErrorExtension.swift */; };
-		OBJ_98 /* XMLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* XMLEncoder.swift */; };
-		OBJ_99 /* XMLEncodingStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* XMLEncodingStorage.swift */; };
+		OBJ_100 /* XMLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* XMLEncoder.swift */; };
+		OBJ_101 /* XMLEncodingStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* XMLEncodingStorage.swift */; };
+		OBJ_102 /* XMLReferencingEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* XMLReferencingEncoder.swift */; };
+		OBJ_103 /* ISO8601DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* ISO8601DateFormatter.swift */; };
+		OBJ_104 /* XMLKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* XMLKey.swift */; };
+		OBJ_105 /* XMLStackParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* XMLStackParser.swift */; };
+		OBJ_112 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* Package.swift */; };
+		OBJ_117 /* Archive+Reading.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* Archive+Reading.swift */; };
+		OBJ_118 /* Archive+Writing.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* Archive+Writing.swift */; };
+		OBJ_119 /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* Archive.swift */; };
+		OBJ_120 /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* Data+Compression.swift */; };
+		OBJ_121 /* Data+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* Data+Serialization.swift */; };
+		OBJ_122 /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* Entry.swift */; };
+		OBJ_123 /* FileManager+ZIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* FileManager+ZIP.swift */; };
+		OBJ_130 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* Package.swift */; };
+		OBJ_55 /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* CoreXLSX.swift */; };
+		OBJ_56 /* Relationships.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Relationships.swift */; };
+		OBJ_57 /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* Worksheet.swift */; };
+		OBJ_59 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */; };
+		OBJ_60 /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XMLCoder::XMLCoder::Product" /* XMLCoder.framework */; };
+		OBJ_70 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_81 /* CoreXLSXTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* CoreXLSXTests.swift */; };
+		OBJ_82 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* XCTestManifests.swift */; };
+		OBJ_84 /* CoreXLSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */; };
+		OBJ_85 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */; };
+		OBJ_86 /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XMLCoder::XMLCoder::Product" /* XMLCoder.framework */; };
+		OBJ_94 /* DecodingErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* DecodingErrorExtension.swift */; };
+		OBJ_95 /* XMLDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* XMLDecoder.swift */; };
+		OBJ_96 /* XMLDecodingStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* XMLDecodingStorage.swift */; };
+		OBJ_97 /* XMLKeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* XMLKeyedDecodingContainer.swift */; };
+		OBJ_98 /* XMLUnkeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* XMLUnkeyedDecodingContainer.swift */; };
+		OBJ_99 /* EncodingErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* EncodingErrorExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		D18E7E77218507AF00E0A487 /* PBXContainerItemProxy */ = {
+		D1B8A6F22198330900605F6D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "ZIPFoundation::ZIPFoundation";
 			remoteInfo = ZIPFoundation;
 		};
-		D18E7E78218507AF00E0A487 /* PBXContainerItemProxy */ = {
+		D1B8A6F32198330900605F6D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "XMLParsing::XMLParsing";
-			remoteInfo = XMLParsing;
+			remoteGlobalIDString = "XMLCoder::XMLCoder";
+			remoteInfo = XMLCoder;
 		};
-		D18E7E79218507AF00E0A487 /* PBXContainerItemProxy */ = {
+		D1B8A6F42198330900605F6D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "CoreXLSX::CoreXLSX";
 			remoteInfo = CoreXLSX;
 		};
-		D18E7E7A218507AF00E0A487 /* PBXContainerItemProxy */ = {
+		D1B8A6F52198330900605F6D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "ZIPFoundation::ZIPFoundation";
 			remoteInfo = ZIPFoundation;
 		};
-		D18E7E7B218507AF00E0A487 /* PBXContainerItemProxy */ = {
+		D1B8A6F62198330900605F6D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "XMLParsing::XMLParsing";
-			remoteInfo = XMLParsing;
+			remoteGlobalIDString = "XMLCoder::XMLCoder";
+			remoteInfo = XMLCoder;
 		};
-		D18E7E7C218507B100E0A487 /* PBXContainerItemProxy */ = {
+		D1B8A6F72198330A00605F6D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
@@ -103,199 +103,198 @@
 /* Begin PBXFileReference section */
 		"CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CoreXLSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = CoreXLSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D11B79B12189BD62005AF0C6 /* Worksheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Worksheet.swift; sourceTree = "<group>"; };
-		D1982972219759CA00C6A761 /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .travis.yml; sourceTree = "<group>"; };
-		D198297321975A4100C6A761 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		D1982974219764D600C6A761 /* LICENSE.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
-		D1982975219766E900C6A761 /* CoreXLSX.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreXLSX.podspec; sourceTree = "<group>"; };
+		D1B8A6F821983DB800605F6D /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		D1B8A6F921983DB800605F6D /* CoreXLSX.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreXLSX.podspec; sourceTree = "<group>"; };
 		OBJ_10 /* Relationships.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Relationships.swift; sourceTree = "<group>"; };
-		OBJ_13 /* CoreXLSXTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSXTests.swift; sourceTree = "<group>"; };
-		OBJ_14 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
-		OBJ_19 /* Archive+Reading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Reading.swift"; sourceTree = "<group>"; };
-		OBJ_20 /* Archive+Writing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Writing.swift"; sourceTree = "<group>"; };
-		OBJ_21 /* Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Archive.swift; sourceTree = "<group>"; };
-		OBJ_22 /* Data+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Compression.swift"; sourceTree = "<group>"; };
-		OBJ_23 /* Data+Serialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Serialization.swift"; sourceTree = "<group>"; };
-		OBJ_24 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
-		OBJ_25 /* FileManager+ZIP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+ZIP.swift"; sourceTree = "<group>"; };
-		OBJ_26 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/maxd/Documents/CoreXLSX/.build/checkouts/ZIPFoundation.git--2631978234166896080/Package.swift"; sourceTree = "<group>"; };
-		OBJ_30 /* DecodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingErrorExtension.swift; sourceTree = "<group>"; };
-		OBJ_31 /* XMLDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLDecoder.swift; sourceTree = "<group>"; };
-		OBJ_32 /* XMLDecodingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLDecodingStorage.swift; sourceTree = "<group>"; };
-		OBJ_33 /* XMLKeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLKeyedDecodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_34 /* XMLUnkeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLUnkeyedDecodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_36 /* EncodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingErrorExtension.swift; sourceTree = "<group>"; };
-		OBJ_37 /* XMLEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLEncoder.swift; sourceTree = "<group>"; };
-		OBJ_38 /* XMLEncodingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLEncodingStorage.swift; sourceTree = "<group>"; };
-		OBJ_39 /* XMLReferencingEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLReferencingEncoder.swift; sourceTree = "<group>"; };
-		OBJ_40 /* ISO8601DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISO8601DateFormatter.swift; sourceTree = "<group>"; };
-		OBJ_41 /* XMLKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLKey.swift; sourceTree = "<group>"; };
-		OBJ_42 /* XMLStackParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLStackParser.swift; sourceTree = "<group>"; };
-		OBJ_43 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/maxd/Documents/CoreXLSX/.build/checkouts/XMLParsing.git--1187387871924630981/Package.swift"; sourceTree = "<group>"; };
+		OBJ_11 /* Worksheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Worksheet.swift; sourceTree = "<group>"; };
+		OBJ_14 /* CoreXLSXTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSXTests.swift; sourceTree = "<group>"; };
+		OBJ_15 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
+		OBJ_16 /* Example */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Example; sourceTree = SOURCE_ROOT; };
+		OBJ_20 /* Archive+Reading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Reading.swift"; sourceTree = "<group>"; };
+		OBJ_21 /* Archive+Writing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Writing.swift"; sourceTree = "<group>"; };
+		OBJ_22 /* Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Archive.swift; sourceTree = "<group>"; };
+		OBJ_23 /* Data+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Compression.swift"; sourceTree = "<group>"; };
+		OBJ_24 /* Data+Serialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Serialization.swift"; sourceTree = "<group>"; };
+		OBJ_25 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
+		OBJ_26 /* FileManager+ZIP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+ZIP.swift"; sourceTree = "<group>"; };
+		OBJ_27 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/maxd/Documents/CoreXLSX/.build/checkouts/ZIPFoundation.git--2631978234166896080/Package.swift"; sourceTree = "<group>"; };
+		OBJ_31 /* DecodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingErrorExtension.swift; sourceTree = "<group>"; };
+		OBJ_32 /* XMLDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLDecoder.swift; sourceTree = "<group>"; };
+		OBJ_33 /* XMLDecodingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLDecodingStorage.swift; sourceTree = "<group>"; };
+		OBJ_34 /* XMLKeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLKeyedDecodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_35 /* XMLUnkeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLUnkeyedDecodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_37 /* EncodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingErrorExtension.swift; sourceTree = "<group>"; };
+		OBJ_38 /* XMLEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLEncoder.swift; sourceTree = "<group>"; };
+		OBJ_39 /* XMLEncodingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLEncodingStorage.swift; sourceTree = "<group>"; };
+		OBJ_40 /* XMLReferencingEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLReferencingEncoder.swift; sourceTree = "<group>"; };
+		OBJ_41 /* ISO8601DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISO8601DateFormatter.swift; sourceTree = "<group>"; };
+		OBJ_42 /* XMLKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLKey.swift; sourceTree = "<group>"; };
+		OBJ_43 /* XMLStackParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLStackParser.swift; sourceTree = "<group>"; };
+		OBJ_44 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/maxd/Documents/CoreXLSX/.build/checkouts/XMLCoder.git--2466284176948894372/Package.swift"; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		OBJ_9 /* CoreXLSX.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = CoreXLSX.swift; sourceTree = "<group>"; tabWidth = 2; };
-		"XMLParsing::XMLParsing::Product" /* XMLParsing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = XMLParsing.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_9 /* CoreXLSX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSX.swift; sourceTree = "<group>"; };
+		"XMLCoder::XMLCoder::Product" /* XMLCoder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = XMLCoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ZIPFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		OBJ_104 /* Frameworks */ = {
+		OBJ_106 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_122 /* Frameworks */ = {
+		OBJ_124 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_56 /* Frameworks */ = {
+		OBJ_58 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_57 /* ZIPFoundation.framework in Frameworks */,
-				OBJ_58 /* XMLParsing.framework in Frameworks */,
+				OBJ_59 /* ZIPFoundation.framework in Frameworks */,
+				OBJ_60 /* XMLCoder.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_81 /* Frameworks */ = {
+		OBJ_83 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_82 /* CoreXLSX.framework in Frameworks */,
-				OBJ_83 /* ZIPFoundation.framework in Frameworks */,
-				OBJ_84 /* XMLParsing.framework in Frameworks */,
+				OBJ_84 /* CoreXLSX.framework in Frameworks */,
+				OBJ_85 /* ZIPFoundation.framework in Frameworks */,
+				OBJ_86 /* XMLCoder.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		OBJ_11 /* Tests */ = {
+		OBJ_12 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_12 /* CoreXLSXTests */,
+				OBJ_13 /* CoreXLSXTests */,
 			);
 			name = Tests;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_12 /* CoreXLSXTests */ = {
+		OBJ_13 /* CoreXLSXTests */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_13 /* CoreXLSXTests.swift */,
-				OBJ_14 /* XCTestManifests.swift */,
+				OBJ_14 /* CoreXLSXTests.swift */,
+				OBJ_15 /* XCTestManifests.swift */,
 			);
 			name = CoreXLSXTests;
 			path = Tests/CoreXLSXTests;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_16 /* Dependencies */ = {
+		OBJ_17 /* Dependencies */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_17 /* ZIPFoundation 0.9.6 */,
-				OBJ_27 /* XMLParsing */,
+				OBJ_18 /* ZIPFoundation 0.9.6 */,
+				OBJ_28 /* XMLCoder 0.1.0 */,
 			);
 			name = Dependencies;
 			sourceTree = "<group>";
 		};
-		OBJ_17 /* ZIPFoundation 0.9.6 */ = {
+		OBJ_18 /* ZIPFoundation 0.9.6 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_18 /* ZIPFoundation */,
-				OBJ_26 /* Package.swift */,
+				OBJ_19 /* ZIPFoundation */,
+				OBJ_27 /* Package.swift */,
 			);
 			name = "ZIPFoundation 0.9.6";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_18 /* ZIPFoundation */ = {
+		OBJ_19 /* ZIPFoundation */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_19 /* Archive+Reading.swift */,
-				OBJ_20 /* Archive+Writing.swift */,
-				OBJ_21 /* Archive.swift */,
-				OBJ_22 /* Data+Compression.swift */,
-				OBJ_23 /* Data+Serialization.swift */,
-				OBJ_24 /* Entry.swift */,
-				OBJ_25 /* FileManager+ZIP.swift */,
+				OBJ_20 /* Archive+Reading.swift */,
+				OBJ_21 /* Archive+Writing.swift */,
+				OBJ_22 /* Archive.swift */,
+				OBJ_23 /* Data+Compression.swift */,
+				OBJ_24 /* Data+Serialization.swift */,
+				OBJ_25 /* Entry.swift */,
+				OBJ_26 /* FileManager+ZIP.swift */,
 			);
 			name = ZIPFoundation;
 			path = ".build/checkouts/ZIPFoundation.git--2631978234166896080/Sources/ZIPFoundation";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_27 /* XMLParsing */ = {
+		OBJ_28 /* XMLCoder 0.1.0 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_28 /* XMLParsing */,
-				OBJ_43 /* Package.swift */,
+				OBJ_29 /* XMLCoder */,
+				OBJ_44 /* Package.swift */,
 			);
-			name = XMLParsing;
+			name = "XMLCoder 0.1.0";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_28 /* XMLParsing */ = {
+		OBJ_29 /* XMLCoder */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_29 /* Decoder */,
-				OBJ_35 /* Encoder */,
-				OBJ_40 /* ISO8601DateFormatter.swift */,
-				OBJ_41 /* XMLKey.swift */,
-				OBJ_42 /* XMLStackParser.swift */,
+				OBJ_30 /* Decoder */,
+				OBJ_36 /* Encoder */,
+				OBJ_41 /* ISO8601DateFormatter.swift */,
+				OBJ_42 /* XMLKey.swift */,
+				OBJ_43 /* XMLStackParser.swift */,
 			);
-			name = XMLParsing;
-			path = ".build/checkouts/XMLParsing.git--1187387871924630981/Sources/XMLParsing";
+			name = XMLCoder;
+			path = ".build/checkouts/XMLCoder.git--2466284176948894372/Sources/XMLCoder";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_29 /* Decoder */ = {
+		OBJ_30 /* Decoder */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_30 /* DecodingErrorExtension.swift */,
-				OBJ_31 /* XMLDecoder.swift */,
-				OBJ_32 /* XMLDecodingStorage.swift */,
-				OBJ_33 /* XMLKeyedDecodingContainer.swift */,
-				OBJ_34 /* XMLUnkeyedDecodingContainer.swift */,
+				OBJ_31 /* DecodingErrorExtension.swift */,
+				OBJ_32 /* XMLDecoder.swift */,
+				OBJ_33 /* XMLDecodingStorage.swift */,
+				OBJ_34 /* XMLKeyedDecodingContainer.swift */,
+				OBJ_35 /* XMLUnkeyedDecodingContainer.swift */,
 			);
 			path = Decoder;
 			sourceTree = "<group>";
 		};
-		OBJ_35 /* Encoder */ = {
+		OBJ_36 /* Encoder */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_36 /* EncodingErrorExtension.swift */,
-				OBJ_37 /* XMLEncoder.swift */,
-				OBJ_38 /* XMLEncodingStorage.swift */,
-				OBJ_39 /* XMLReferencingEncoder.swift */,
+				OBJ_37 /* EncodingErrorExtension.swift */,
+				OBJ_38 /* XMLEncoder.swift */,
+				OBJ_39 /* XMLEncodingStorage.swift */,
+				OBJ_40 /* XMLReferencingEncoder.swift */,
 			);
 			path = Encoder;
 			sourceTree = "<group>";
 		};
-		OBJ_44 /* Products */ = {
+		OBJ_45 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				"XMLParsing::XMLParsing::Product" /* XMLParsing.framework */,
-				"CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */,
-				"CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */,
 				"ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */,
+				"XMLCoder::XMLCoder::Product" /* XMLCoder.framework */,
+				"CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */,
+				"CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */,
 			);
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		OBJ_5 = {
+		OBJ_5 /*  */ = {
 			isa = PBXGroup;
 			children = (
-				D1982975219766E900C6A761 /* CoreXLSX.podspec */,
-				D1982974219764D600C6A761 /* LICENSE.md */,
-				D198297321975A4100C6A761 /* README.md */,
-				D1982972219759CA00C6A761 /* .travis.yml */,
+				D1B8A6F921983DB800605F6D /* CoreXLSX.podspec */,
+				D1B8A6F821983DB800605F6D /* README.md */,
 				OBJ_6 /* Package.swift */,
 				OBJ_7 /* Sources */,
-				OBJ_11 /* Tests */,
-				OBJ_16 /* Dependencies */,
-				OBJ_44 /* Products */,
+				OBJ_12 /* Tests */,
+				OBJ_16 /* Example */,
+				OBJ_17 /* Dependencies */,
+				OBJ_45 /* Products */,
 			);
 			indentWidth = 2;
+			name = "";
 			sourceTree = "<group>";
 			tabWidth = 2;
 		};
@@ -312,7 +311,7 @@
 			children = (
 				OBJ_9 /* CoreXLSX.swift */,
 				OBJ_10 /* Relationships.swift */,
-				D11B79B12189BD62005AF0C6 /* Worksheet.swift */,
+				OBJ_11 /* Worksheet.swift */,
 			);
 			name = CoreXLSX;
 			path = Sources/CoreXLSX;
@@ -323,16 +322,16 @@
 /* Begin PBXNativeTarget section */
 		"CoreXLSX::CoreXLSX" /* CoreXLSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_50 /* Build configuration list for PBXNativeTarget "CoreXLSX" */;
+			buildConfigurationList = OBJ_51 /* Build configuration list for PBXNativeTarget "CoreXLSX" */;
 			buildPhases = (
-				OBJ_53 /* Sources */,
-				OBJ_56 /* Frameworks */,
+				OBJ_54 /* Sources */,
+				OBJ_58 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_59 /* PBXTargetDependency */,
 				OBJ_61 /* PBXTargetDependency */,
+				OBJ_63 /* PBXTargetDependency */,
 			);
 			name = CoreXLSX;
 			productName = CoreXLSX;
@@ -341,17 +340,17 @@
 		};
 		"CoreXLSX::CoreXLSXTests" /* CoreXLSXTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_75 /* Build configuration list for PBXNativeTarget "CoreXLSXTests" */;
+			buildConfigurationList = OBJ_77 /* Build configuration list for PBXNativeTarget "CoreXLSXTests" */;
 			buildPhases = (
-				OBJ_78 /* Sources */,
-				OBJ_81 /* Frameworks */,
+				OBJ_80 /* Sources */,
+				OBJ_83 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_85 /* PBXTargetDependency */,
-				OBJ_86 /* PBXTargetDependency */,
 				OBJ_87 /* PBXTargetDependency */,
+				OBJ_88 /* PBXTargetDependency */,
+				OBJ_89 /* PBXTargetDependency */,
 			);
 			name = CoreXLSXTests;
 			productName = CoreXLSXTests;
@@ -360,9 +359,9 @@
 		};
 		"CoreXLSX::SwiftPMPackageDescription" /* CoreXLSXPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_64 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */;
+			buildConfigurationList = OBJ_66 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */;
 			buildPhases = (
-				OBJ_67 /* Sources */,
+				OBJ_69 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -372,41 +371,41 @@
 			productName = CoreXLSXPackageDescription;
 			productType = "com.apple.product-type.framework";
 		};
-		"XMLParsing::SwiftPMPackageDescription" /* XMLParsingPackageDescription */ = {
+		"XMLCoder::SwiftPMPackageDescription" /* XMLCoderPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_106 /* Build configuration list for PBXNativeTarget "XMLParsingPackageDescription" */;
+			buildConfigurationList = OBJ_108 /* Build configuration list for PBXNativeTarget "XMLCoderPackageDescription" */;
 			buildPhases = (
-				OBJ_109 /* Sources */,
+				OBJ_111 /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = XMLParsingPackageDescription;
-			productName = XMLParsingPackageDescription;
+			name = XMLCoderPackageDescription;
+			productName = XMLCoderPackageDescription;
 			productType = "com.apple.product-type.framework";
 		};
-		"XMLParsing::XMLParsing" /* XMLParsing */ = {
+		"XMLCoder::XMLCoder" /* XMLCoder */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_88 /* Build configuration list for PBXNativeTarget "XMLParsing" */;
+			buildConfigurationList = OBJ_90 /* Build configuration list for PBXNativeTarget "XMLCoder" */;
 			buildPhases = (
-				OBJ_91 /* Sources */,
-				OBJ_104 /* Frameworks */,
+				OBJ_93 /* Sources */,
+				OBJ_106 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = XMLParsing;
-			productName = XMLParsing;
-			productReference = "XMLParsing::XMLParsing::Product" /* XMLParsing.framework */;
+			name = XMLCoder;
+			productName = XMLCoder;
+			productReference = "XMLCoder::XMLCoder::Product" /* XMLCoder.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		"ZIPFoundation::SwiftPMPackageDescription" /* ZIPFoundationPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_124 /* Build configuration list for PBXNativeTarget "ZIPFoundationPackageDescription" */;
+			buildConfigurationList = OBJ_126 /* Build configuration list for PBXNativeTarget "ZIPFoundationPackageDescription" */;
 			buildPhases = (
-				OBJ_127 /* Sources */,
+				OBJ_129 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -418,10 +417,10 @@
 		};
 		"ZIPFoundation::ZIPFoundation" /* ZIPFoundation */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_111 /* Build configuration list for PBXNativeTarget "ZIPFoundation" */;
+			buildConfigurationList = OBJ_113 /* Build configuration list for PBXNativeTarget "ZIPFoundation" */;
 			buildPhases = (
-				OBJ_114 /* Sources */,
-				OBJ_122 /* Frameworks */,
+				OBJ_116 /* Sources */,
+				OBJ_124 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -441,14 +440,14 @@
 				LastUpgradeCheck = 9999;
 			};
 			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "CoreXLSX" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 10.0";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5;
-			productRefGroup = OBJ_44 /* Products */;
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_45 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -456,8 +455,8 @@
 				"CoreXLSX::SwiftPMPackageDescription" /* CoreXLSXPackageDescription */,
 				"CoreXLSX::CoreXLSXPackageTests::ProductTarget" /* CoreXLSXPackageTests */,
 				"CoreXLSX::CoreXLSXTests" /* CoreXLSXTests */,
-				"XMLParsing::XMLParsing" /* XMLParsing */,
-				"XMLParsing::SwiftPMPackageDescription" /* XMLParsingPackageDescription */,
+				"XMLCoder::XMLCoder" /* XMLCoder */,
+				"XMLCoder::SwiftPMPackageDescription" /* XMLCoderPackageDescription */,
 				"ZIPFoundation::ZIPFoundation" /* ZIPFoundation */,
 				"ZIPFoundation::SwiftPMPackageDescription" /* ZIPFoundationPackageDescription */,
 			);
@@ -465,137 +464,137 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		OBJ_109 /* Sources */ = {
+		OBJ_111 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_110 /* Package.swift in Sources */,
+				OBJ_112 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_114 /* Sources */ = {
+		OBJ_116 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_115 /* Archive+Reading.swift in Sources */,
-				OBJ_116 /* Archive+Writing.swift in Sources */,
-				OBJ_117 /* Archive.swift in Sources */,
-				OBJ_118 /* Data+Compression.swift in Sources */,
-				OBJ_119 /* Data+Serialization.swift in Sources */,
-				OBJ_120 /* Entry.swift in Sources */,
-				OBJ_121 /* FileManager+ZIP.swift in Sources */,
+				OBJ_117 /* Archive+Reading.swift in Sources */,
+				OBJ_118 /* Archive+Writing.swift in Sources */,
+				OBJ_119 /* Archive.swift in Sources */,
+				OBJ_120 /* Data+Compression.swift in Sources */,
+				OBJ_121 /* Data+Serialization.swift in Sources */,
+				OBJ_122 /* Entry.swift in Sources */,
+				OBJ_123 /* FileManager+ZIP.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_127 /* Sources */ = {
+		OBJ_129 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_128 /* Package.swift in Sources */,
+				OBJ_130 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_53 /* Sources */ = {
+		OBJ_54 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				D11B79B22189BD62005AF0C6 /* Worksheet.swift in Sources */,
-				OBJ_54 /* CoreXLSX.swift in Sources */,
-				OBJ_55 /* Relationships.swift in Sources */,
+				OBJ_55 /* CoreXLSX.swift in Sources */,
+				OBJ_56 /* Relationships.swift in Sources */,
+				OBJ_57 /* Worksheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_67 /* Sources */ = {
+		OBJ_69 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_68 /* Package.swift in Sources */,
+				OBJ_70 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_78 /* Sources */ = {
+		OBJ_80 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_79 /* CoreXLSXTests.swift in Sources */,
-				OBJ_80 /* XCTestManifests.swift in Sources */,
+				OBJ_81 /* CoreXLSXTests.swift in Sources */,
+				OBJ_82 /* XCTestManifests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_91 /* Sources */ = {
+		OBJ_93 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_92 /* DecodingErrorExtension.swift in Sources */,
-				OBJ_93 /* XMLDecoder.swift in Sources */,
-				OBJ_94 /* XMLDecodingStorage.swift in Sources */,
-				OBJ_95 /* XMLKeyedDecodingContainer.swift in Sources */,
-				OBJ_96 /* XMLUnkeyedDecodingContainer.swift in Sources */,
-				OBJ_97 /* EncodingErrorExtension.swift in Sources */,
-				OBJ_98 /* XMLEncoder.swift in Sources */,
-				OBJ_99 /* XMLEncodingStorage.swift in Sources */,
-				OBJ_100 /* XMLReferencingEncoder.swift in Sources */,
-				OBJ_101 /* ISO8601DateFormatter.swift in Sources */,
-				OBJ_102 /* XMLKey.swift in Sources */,
-				OBJ_103 /* XMLStackParser.swift in Sources */,
+				OBJ_94 /* DecodingErrorExtension.swift in Sources */,
+				OBJ_95 /* XMLDecoder.swift in Sources */,
+				OBJ_96 /* XMLDecodingStorage.swift in Sources */,
+				OBJ_97 /* XMLKeyedDecodingContainer.swift in Sources */,
+				OBJ_98 /* XMLUnkeyedDecodingContainer.swift in Sources */,
+				OBJ_99 /* EncodingErrorExtension.swift in Sources */,
+				OBJ_100 /* XMLEncoder.swift in Sources */,
+				OBJ_101 /* XMLEncodingStorage.swift in Sources */,
+				OBJ_102 /* XMLReferencingEncoder.swift in Sources */,
+				OBJ_103 /* ISO8601DateFormatter.swift in Sources */,
+				OBJ_104 /* XMLKey.swift in Sources */,
+				OBJ_105 /* XMLStackParser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		OBJ_59 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "ZIPFoundation::ZIPFoundation" /* ZIPFoundation */;
-			targetProxy = D18E7E77218507AF00E0A487 /* PBXContainerItemProxy */;
-		};
 		OBJ_61 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "XMLParsing::XMLParsing" /* XMLParsing */;
-			targetProxy = D18E7E78218507AF00E0A487 /* PBXContainerItemProxy */;
+			target = "ZIPFoundation::ZIPFoundation" /* ZIPFoundation */;
+			targetProxy = D1B8A6F22198330900605F6D /* PBXContainerItemProxy */;
 		};
-		OBJ_73 /* PBXTargetDependency */ = {
+		OBJ_63 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "XMLCoder::XMLCoder" /* XMLCoder */;
+			targetProxy = D1B8A6F32198330900605F6D /* PBXContainerItemProxy */;
+		};
+		OBJ_75 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "CoreXLSX::CoreXLSXTests" /* CoreXLSXTests */;
-			targetProxy = D18E7E7C218507B100E0A487 /* PBXContainerItemProxy */;
-		};
-		OBJ_85 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "CoreXLSX::CoreXLSX" /* CoreXLSX */;
-			targetProxy = D18E7E79218507AF00E0A487 /* PBXContainerItemProxy */;
-		};
-		OBJ_86 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "ZIPFoundation::ZIPFoundation" /* ZIPFoundation */;
-			targetProxy = D18E7E7A218507AF00E0A487 /* PBXContainerItemProxy */;
+			targetProxy = D1B8A6F72198330A00605F6D /* PBXContainerItemProxy */;
 		};
 		OBJ_87 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "XMLParsing::XMLParsing" /* XMLParsing */;
-			targetProxy = D18E7E7B218507AF00E0A487 /* PBXContainerItemProxy */;
+			target = "CoreXLSX::CoreXLSX" /* CoreXLSX */;
+			targetProxy = D1B8A6F42198330900605F6D /* PBXContainerItemProxy */;
+		};
+		OBJ_88 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "ZIPFoundation::ZIPFoundation" /* ZIPFoundation */;
+			targetProxy = D1B8A6F52198330900605F6D /* PBXContainerItemProxy */;
+		};
+		OBJ_89 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "XMLCoder::XMLCoder" /* XMLCoder */;
+			targetProxy = D1B8A6F62198330900605F6D /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		OBJ_107 /* Debug */ = {
+		OBJ_109 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode-10.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
-		OBJ_108 /* Release */ = {
+		OBJ_110 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode-10.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
-		OBJ_112 /* Debug */ = {
+		OBJ_114 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -605,7 +604,10 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/ZIPFoundation_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+				);
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -619,7 +621,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_113 /* Release */ = {
+		OBJ_115 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -629,7 +631,10 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/ZIPFoundation_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+				);
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -643,20 +648,20 @@
 			};
 			name = Release;
 		};
-		OBJ_125 /* Debug */ = {
+		OBJ_127 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode-10.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
-		OBJ_126 /* Release */ = {
+		OBJ_128 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode-10.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
@@ -702,12 +707,13 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				USE_HEADERMAP = NO;
 			};
 			name = Release;
 		};
-		OBJ_51 /* Debug */ = {
+		OBJ_52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -717,7 +723,10 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSX_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+				);
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -731,7 +740,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_52 /* Release */ = {
+		OBJ_53 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -741,7 +750,10 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSX_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+				);
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -755,37 +767,37 @@
 			};
 			name = Release;
 		};
-		OBJ_65 /* Debug */ = {
+		OBJ_67 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode-10.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
 				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
-		OBJ_66 /* Release */ = {
+		OBJ_68 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode-10.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
 				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
-		OBJ_71 /* Debug */ = {
+		OBJ_73 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		OBJ_72 /* Release */ = {
+		OBJ_74 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		OBJ_76 /* Debug */ = {
+		OBJ_78 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
@@ -796,7 +808,11 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -806,7 +822,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_77 /* Release */ = {
+		OBJ_79 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
@@ -817,7 +833,11 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -827,7 +847,7 @@
 			};
 			name = Release;
 		};
-		OBJ_89 /* Debug */ = {
+		OBJ_91 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -836,22 +856,25 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = CoreXLSX.xcodeproj/XMLParsing_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				INFOPLIST_FILE = CoreXLSX.xcodeproj/XMLCoder_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+				);
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = XMLParsing;
+				PRODUCT_BUNDLE_IDENTIFIER = XMLCoder;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 4.0;
-				TARGET_NAME = XMLParsing;
+				TARGET_NAME = XMLCoder;
 			};
 			name = Debug;
 		};
-		OBJ_90 /* Release */ = {
+		OBJ_92 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -860,47 +883,50 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = CoreXLSX.xcodeproj/XMLParsing_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				INFOPLIST_FILE = CoreXLSX.xcodeproj/XMLCoder_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+				);
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = XMLParsing;
+				PRODUCT_BUNDLE_IDENTIFIER = XMLCoder;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 4.0;
-				TARGET_NAME = XMLParsing;
+				TARGET_NAME = XMLCoder;
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		OBJ_106 /* Build configuration list for PBXNativeTarget "XMLParsingPackageDescription" */ = {
+		OBJ_108 /* Build configuration list for PBXNativeTarget "XMLCoderPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_107 /* Debug */,
-				OBJ_108 /* Release */,
+				OBJ_109 /* Debug */,
+				OBJ_110 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_111 /* Build configuration list for PBXNativeTarget "ZIPFoundation" */ = {
+		OBJ_113 /* Build configuration list for PBXNativeTarget "ZIPFoundation" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_112 /* Debug */,
-				OBJ_113 /* Release */,
+				OBJ_114 /* Debug */,
+				OBJ_115 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_124 /* Build configuration list for PBXNativeTarget "ZIPFoundationPackageDescription" */ = {
+		OBJ_126 /* Build configuration list for PBXNativeTarget "ZIPFoundationPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_125 /* Debug */,
-				OBJ_126 /* Release */,
+				OBJ_127 /* Debug */,
+				OBJ_128 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -914,47 +940,47 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_50 /* Build configuration list for PBXNativeTarget "CoreXLSX" */ = {
+		OBJ_51 /* Build configuration list for PBXNativeTarget "CoreXLSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_51 /* Debug */,
-				OBJ_52 /* Release */,
+				OBJ_52 /* Debug */,
+				OBJ_53 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_64 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */ = {
+		OBJ_66 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_65 /* Debug */,
-				OBJ_66 /* Release */,
+				OBJ_67 /* Debug */,
+				OBJ_68 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_70 /* Build configuration list for PBXAggregateTarget "CoreXLSXPackageTests" */ = {
+		OBJ_72 /* Build configuration list for PBXAggregateTarget "CoreXLSXPackageTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_71 /* Debug */,
-				OBJ_72 /* Release */,
+				OBJ_73 /* Debug */,
+				OBJ_74 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_75 /* Build configuration list for PBXNativeTarget "CoreXLSXTests" */ = {
+		OBJ_77 /* Build configuration list for PBXNativeTarget "CoreXLSXTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_76 /* Debug */,
-				OBJ_77 /* Release */,
+				OBJ_78 /* Debug */,
+				OBJ_79 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_88 /* Build configuration list for PBXNativeTarget "XMLParsing" */ = {
+		OBJ_90 /* Build configuration list for PBXNativeTarget "XMLCoder" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_89 /* Debug */,
-				OBJ_90 /* Release */,
+				OBJ_91 /* Debug */,
+				OBJ_92 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/CoreXLSX.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/CoreXLSX.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CoreXLSX.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CoreXLSX.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/CoreXLSX.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/CoreXLSX.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+    <false/>
+</dict>
+</plist>

--- a/CoreXLSX.xcodeproj/xcshareddata/xcschemes/CoreXLSX-Package.xcscheme
+++ b/CoreXLSX.xcodeproj/xcshareddata/xcschemes/CoreXLSX-Package.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,22 +40,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CoreXLSX::CoreXLSX"
-            BuildableName = "CoreXLSX.framework"
-            BlueprintName = "CoreXLSX"
-            ReferencedContainer = "container:CoreXLSX.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "TESTS_PATH"
-            value = "${SRCROOT}/Tests/CoreXLSXTests"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -77,6 +62,13 @@
             ReferencedContainer = "container:CoreXLSX.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "TESTS_PATH"
+            value = "${SRCROOT}/Tests/CoreXLSXTests"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "XMLParsing",
-        "repositoryURL": "https://github.com/maxdesiatov/XMLParsing.git",
+        "package": "XMLCoder",
+        "repositoryURL": "https://github.com/maxdesiatov/XMLCoder.git",
         "state": {
-          "branch": "master",
-          "revision": "6d147739c7aa52b6b6d7ec5fd0d58740397ee233",
-          "version": null
+          "branch": null,
+          "revision": "4f28712b99d2ba94005c4d5c790fac509efc5493",
+          "version": "0.1.0"
         }
       },
       {

--- a/Package.xcconfig
+++ b/Package.xcconfig
@@ -1,0 +1,10 @@
+/// Package.xcconfig
+
+/// macOS Deployment Target
+/// 
+/// Code will load on this and later versions of macOS. 
+/// Framework APIs that are unavailable in earlier versions will be weak-linked; 
+/// your code should check for `null` function pointers 
+/// or specific system versions before calling newer APIs.
+
+MACOSX_DEPLOYMENT_TARGET=10.11

--- a/Sources/CoreXLSX/CoreXLSX.swift
+++ b/Sources/CoreXLSX/CoreXLSX.swift
@@ -10,6 +10,7 @@ public struct XLSXFile {
   public let filepath: String
   private let archive: Archive
   private let decoder: XMLDecoder
+  private let worksheetCache: [String: Worksheet]
 
   public init?(filepath: String) {
     let archiveURL = URL(fileURLWithPath: filepath)
@@ -71,6 +72,23 @@ public struct XLSXFile {
   public func parseWorksheet(at path: String) throws -> Worksheet {
     decoder.keyDecodingStrategy = .useDefaultKeys
 
-    return try parseEntry(path, Worksheet.self)
+    guard let result = worksheetCache[path] else {
+      return try parseEntry(path, Worksheet.self)
+    }
+
+    return result
+  }
+
+  public func cellsInWorksheet(at path: String, rows: [Int]) throws -> [Cell] {
+    let ws = parseWorksheet(at: path)
+
+    let references = rows.map { "\($0)" }
+    return ws.sheetData.rows.filter { references.contains($0.reference) }
+      .reduce([]) { $0 + $1 }
+  }
+
+  public func cellsInWorksheet(at path: String, columns: [String]) throws
+  -> [Cell] {
+    return []
   }
 }

--- a/Sources/CoreXLSX/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet.swift
@@ -85,7 +85,7 @@ public struct SheetData: Codable {
 }
 
 public struct Row: Codable {
-  public let reference: String
+  public let reference: Int
   public let ht: String?
   public let customHeight: String?
   public let cells: [Cell]
@@ -98,7 +98,7 @@ public struct Row: Codable {
   }
 }
 
-public struct Cell: Codable {
+public struct Cell: Codable, Equatable {
   public let reference: String
   public let type: String?
   public let s: String?
@@ -130,7 +130,7 @@ public struct MergeCell: Codable {
   public let ref: String
 }
 
-public struct InlineString: Codable {
+public struct InlineString: Codable, Equatable {
   let text: String?
 
   enum CodingKeys: String, CodingKey {

--- a/Sources/CoreXLSX/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet.swift
@@ -85,14 +85,14 @@ public struct SheetData: Codable {
 }
 
 public struct Row: Codable {
-  public let r: String
+  public let reference: String
   public let ht: String?
   public let customHeight: String?
   public let cells: [Cell]
 
   enum CodingKeys: String, CodingKey {
     case cells = "c"
-    case r
+    case reference = "r"
     case ht
     case customHeight
   }

--- a/Tests/CoreXLSXTests/CoreXLSXTests.swift
+++ b/Tests/CoreXLSXTests/CoreXLSXTests.swift
@@ -2,26 +2,47 @@ import XCTest
 @testable import CoreXLSX
 
 final class XLSXReaderTests: XCTestCase {
-  func testExample() {
+  func testCategoriesFile() {
     let currentWorkingPath = ProcessInfo.processInfo.environment["TESTS_PATH"]!
 
     do {
-      let file = XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx")
+      guard let file =
+      XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
+        XCTAssert(false, "failed to open the file")
+        return
+      }
       let sheetPath = "xl/worksheets/sheet1.xml"
 
-      XCTAssertEqual(try file?.parseDocumentPaths(), ["xl/workbook.xml"])
-      XCTAssertEqual(try file?.parseWorksheetPaths(), [sheetPath])
-      let ws = try file?.parseWorksheet(at: sheetPath)
-      let totalCellCount = ws?.sheetData.rows
-        .map { $0.cells.count }
-        .reduce(0, { $0 + $1 })
-      XCTAssertEqual(totalCellCount, 90)
+      XCTAssertEqual(try file.parseDocumentPaths(), ["xl/workbook.xml"])
+      XCTAssertEqual(try file.parseWorksheetPaths(), [sheetPath])
+
+      let ws = try file.parseWorksheet(at: sheetPath)
+      let allCells = ws.sheetData.rows
+        .map { $0.cells }
+        .reduce([], { $0 + $1 })
+      XCTAssertEqual(allCells.count, 90)
+
+      let rowReferences = ws.sheetData.rows.map { $0.reference }
+      let cellsFromRows = try file.cellsInWorksheet(at: sheetPath,
+                                                    rows: rowReferences)
+      XCTAssertEqual(allCells, cellsFromRows)
+
+      let cellsInFirstRow = try file.cellsInWorksheet(at: sheetPath, rows: [1])
+      XCTAssertEqual(cellsInFirstRow.count, 6)
+
+      let firstColumn = ("A" as UnicodeScalar).value
+      let lastColumn = ("F" as UnicodeScalar).value
+      let columnReferences = (firstColumn...lastColumn)
+        .compactMap { UnicodeScalar($0) }.map { String($0) }
+      let cellsFromAllColumns =
+        try file.cellsInWorksheet(at: sheetPath, columns: columnReferences)
+      XCTAssertEqual(allCells, cellsFromAllColumns)
     } catch {
       XCTAssert(false, "unexpected error \(error)")
     }
   }
 
   static var allTests = [
-    ("testExample", testExample),
+    ("testCategoriesFile", testCategoriesFile),
   ]
 }

--- a/_Pods.xcodeproj
+++ b/_Pods.xcodeproj
@@ -1,1 +1,0 @@
-Example/Pods/Pods.xcodeproj


### PR DESCRIPTION
This new API allows users to filter all cells by a row or column reference. To avoid re-parsing of worksheets, a new private `worksheetCache` property is added on `XLSXFile`.