### PR TITLE
Improve Worksheet model property naming

### DIFF
--- a/CoreXLSX.xcodeproj/project.pbxproj
+++ b/CoreXLSX.xcodeproj/project.pbxproj
@@ -3,17 +3,17 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
 		"CoreXLSX::CoreXLSXPackageTests::ProductTarget" /* CoreXLSXPackageTests */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = OBJ_72 /* Build configuration list for PBXAggregateTarget "CoreXLSXPackageTests" */;
+			buildConfigurationList = OBJ_74 /* Build configuration list for PBXAggregateTarget "CoreXLSXPackageTests" */;
 			buildPhases = (
 			);
 			dependencies = (
-				OBJ_75 /* PBXTargetDependency */,
+				OBJ_77 /* PBXTargetDependency */,
 			);
 			name = CoreXLSXPackageTests;
 			productName = CoreXLSXPackageTests;
@@ -21,77 +21,77 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		OBJ_100 /* XMLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* XMLEncoder.swift */; };
-		OBJ_101 /* XMLEncodingStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* XMLEncodingStorage.swift */; };
-		OBJ_102 /* XMLReferencingEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* XMLReferencingEncoder.swift */; };
-		OBJ_103 /* ISO8601DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* ISO8601DateFormatter.swift */; };
-		OBJ_104 /* XMLKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* XMLKey.swift */; };
-		OBJ_105 /* XMLStackParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* XMLStackParser.swift */; };
-		OBJ_112 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* Package.swift */; };
-		OBJ_117 /* Archive+Reading.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* Archive+Reading.swift */; };
-		OBJ_118 /* Archive+Writing.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* Archive+Writing.swift */; };
-		OBJ_119 /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* Archive.swift */; };
-		OBJ_120 /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* Data+Compression.swift */; };
-		OBJ_121 /* Data+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* Data+Serialization.swift */; };
-		OBJ_122 /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* Entry.swift */; };
-		OBJ_123 /* FileManager+ZIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* FileManager+ZIP.swift */; };
-		OBJ_130 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* Package.swift */; };
-		OBJ_55 /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* CoreXLSX.swift */; };
-		OBJ_56 /* Relationships.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Relationships.swift */; };
-		OBJ_57 /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* Worksheet.swift */; };
-		OBJ_59 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */; };
-		OBJ_60 /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XMLCoder::XMLCoder::Product" /* XMLCoder.framework */; };
-		OBJ_70 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
-		OBJ_81 /* CoreXLSXTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* CoreXLSXTests.swift */; };
-		OBJ_82 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* XCTestManifests.swift */; };
-		OBJ_84 /* CoreXLSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */; };
-		OBJ_85 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */; };
-		OBJ_86 /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XMLCoder::XMLCoder::Product" /* XMLCoder.framework */; };
-		OBJ_94 /* DecodingErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* DecodingErrorExtension.swift */; };
-		OBJ_95 /* XMLDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* XMLDecoder.swift */; };
-		OBJ_96 /* XMLDecodingStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* XMLDecodingStorage.swift */; };
-		OBJ_97 /* XMLKeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* XMLKeyedDecodingContainer.swift */; };
-		OBJ_98 /* XMLUnkeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* XMLUnkeyedDecodingContainer.swift */; };
-		OBJ_99 /* EncodingErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* EncodingErrorExtension.swift */; };
+		OBJ_100 /* XMLUnkeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* XMLUnkeyedDecodingContainer.swift */; };
+		OBJ_101 /* EncodingErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* EncodingErrorExtension.swift */; };
+		OBJ_102 /* XMLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* XMLEncoder.swift */; };
+		OBJ_103 /* XMLEncodingStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* XMLEncodingStorage.swift */; };
+		OBJ_104 /* XMLReferencingEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* XMLReferencingEncoder.swift */; };
+		OBJ_105 /* ISO8601DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* ISO8601DateFormatter.swift */; };
+		OBJ_106 /* XMLKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* XMLKey.swift */; };
+		OBJ_107 /* XMLStackParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_45 /* XMLStackParser.swift */; };
+		OBJ_114 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_46 /* Package.swift */; };
+		OBJ_119 /* Archive+Reading.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* Archive+Reading.swift */; };
+		OBJ_120 /* Archive+Writing.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* Archive+Writing.swift */; };
+		OBJ_121 /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* Archive.swift */; };
+		OBJ_122 /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* Data+Compression.swift */; };
+		OBJ_123 /* Data+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* Data+Serialization.swift */; };
+		OBJ_124 /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* Entry.swift */; };
+		OBJ_125 /* FileManager+ZIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* FileManager+ZIP.swift */; };
+		OBJ_132 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* Package.swift */; };
+		OBJ_57 /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* CoreXLSX.swift */; };
+		OBJ_58 /* Relationships.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* Relationships.swift */; };
+		OBJ_59 /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* Worksheet.swift */; };
+		OBJ_61 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */; };
+		OBJ_62 /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XMLCoder::XMLCoder::Product" /* XMLCoder.framework */; };
+		OBJ_72 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_83 /* CoreXLSXTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* CoreXLSXTests.swift */; };
+		OBJ_84 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* XCTestManifests.swift */; };
+		OBJ_86 /* CoreXLSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */; };
+		OBJ_87 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */; };
+		OBJ_88 /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XMLCoder::XMLCoder::Product" /* XMLCoder.framework */; };
+		OBJ_96 /* DecodingErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* DecodingErrorExtension.swift */; };
+		OBJ_97 /* XMLDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* XMLDecoder.swift */; };
+		OBJ_98 /* XMLDecodingStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* XMLDecodingStorage.swift */; };
+		OBJ_99 /* XMLKeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_36 /* XMLKeyedDecodingContainer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		D1B8A6F22198330900605F6D /* PBXContainerItemProxy */ = {
+		D155EAEF219ADA9E00D4F47E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "ZIPFoundation::ZIPFoundation";
 			remoteInfo = ZIPFoundation;
 		};
-		D1B8A6F32198330900605F6D /* PBXContainerItemProxy */ = {
+		D155EAF0219ADA9E00D4F47E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "XMLCoder::XMLCoder";
 			remoteInfo = XMLCoder;
 		};
-		D1B8A6F42198330900605F6D /* PBXContainerItemProxy */ = {
+		D155EAF1219ADA9E00D4F47E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "CoreXLSX::CoreXLSX";
 			remoteInfo = CoreXLSX;
 		};
-		D1B8A6F52198330900605F6D /* PBXContainerItemProxy */ = {
+		D155EAF2219ADA9E00D4F47E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "ZIPFoundation::ZIPFoundation";
 			remoteInfo = ZIPFoundation;
 		};
-		D1B8A6F62198330900605F6D /* PBXContainerItemProxy */ = {
+		D155EAF3219ADA9E00D4F47E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "XMLCoder::XMLCoder";
 			remoteInfo = XMLCoder;
 		};
-		D1B8A6F72198330A00605F6D /* PBXContainerItemProxy */ = {
+		D155EAF4219ADA9E00D4F47E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
@@ -103,179 +103,189 @@
 /* Begin PBXFileReference section */
 		"CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CoreXLSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = CoreXLSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D1B8A6F821983DB800605F6D /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		D1B8A6F921983DB800605F6D /* CoreXLSX.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreXLSX.podspec; sourceTree = "<group>"; };
-		OBJ_10 /* Relationships.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Relationships.swift; sourceTree = "<group>"; };
-		OBJ_11 /* Worksheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Worksheet.swift; sourceTree = "<group>"; };
-		OBJ_14 /* CoreXLSXTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSXTests.swift; sourceTree = "<group>"; };
-		OBJ_15 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
-		OBJ_16 /* Example */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Example; sourceTree = SOURCE_ROOT; };
-		OBJ_20 /* Archive+Reading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Reading.swift"; sourceTree = "<group>"; };
-		OBJ_21 /* Archive+Writing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Writing.swift"; sourceTree = "<group>"; };
-		OBJ_22 /* Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Archive.swift; sourceTree = "<group>"; };
-		OBJ_23 /* Data+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Compression.swift"; sourceTree = "<group>"; };
-		OBJ_24 /* Data+Serialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Serialization.swift"; sourceTree = "<group>"; };
-		OBJ_25 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
-		OBJ_26 /* FileManager+ZIP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+ZIP.swift"; sourceTree = "<group>"; };
-		OBJ_27 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/maxd/Documents/CoreXLSX/.build/checkouts/ZIPFoundation.git--2631978234166896080/Package.swift"; sourceTree = "<group>"; };
-		OBJ_31 /* DecodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingErrorExtension.swift; sourceTree = "<group>"; };
-		OBJ_32 /* XMLDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLDecoder.swift; sourceTree = "<group>"; };
-		OBJ_33 /* XMLDecodingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLDecodingStorage.swift; sourceTree = "<group>"; };
-		OBJ_34 /* XMLKeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLKeyedDecodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_35 /* XMLUnkeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLUnkeyedDecodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_37 /* EncodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingErrorExtension.swift; sourceTree = "<group>"; };
-		OBJ_38 /* XMLEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLEncoder.swift; sourceTree = "<group>"; };
-		OBJ_39 /* XMLEncodingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLEncodingStorage.swift; sourceTree = "<group>"; };
-		OBJ_40 /* XMLReferencingEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLReferencingEncoder.swift; sourceTree = "<group>"; };
-		OBJ_41 /* ISO8601DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISO8601DateFormatter.swift; sourceTree = "<group>"; };
-		OBJ_42 /* XMLKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLKey.swift; sourceTree = "<group>"; };
-		OBJ_43 /* XMLStackParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLStackParser.swift; sourceTree = "<group>"; };
-		OBJ_44 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/maxd/Documents/CoreXLSX/.build/checkouts/XMLCoder.git--2466284176948894372/Package.swift"; sourceTree = "<group>"; };
+		OBJ_11 /* CoreXLSX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSX.swift; sourceTree = "<group>"; };
+		OBJ_12 /* Relationships.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Relationships.swift; sourceTree = "<group>"; };
+		OBJ_13 /* Worksheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Worksheet.swift; sourceTree = "<group>"; };
+		OBJ_16 /* CoreXLSXTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSXTests.swift; sourceTree = "<group>"; };
+		OBJ_17 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
+		OBJ_18 /* Example */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Example; sourceTree = SOURCE_ROOT; };
+		OBJ_22 /* Archive+Reading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Reading.swift"; sourceTree = "<group>"; };
+		OBJ_23 /* Archive+Writing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Writing.swift"; sourceTree = "<group>"; };
+		OBJ_24 /* Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Archive.swift; sourceTree = "<group>"; };
+		OBJ_25 /* Data+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Compression.swift"; sourceTree = "<group>"; };
+		OBJ_26 /* Data+Serialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Serialization.swift"; sourceTree = "<group>"; };
+		OBJ_27 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
+		OBJ_28 /* FileManager+ZIP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+ZIP.swift"; sourceTree = "<group>"; };
+		OBJ_29 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/maxd/Documents/CoreXLSX/.build/checkouts/ZIPFoundation.git-1553630773966528904/Package.swift"; sourceTree = "<group>"; };
+		OBJ_33 /* DecodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingErrorExtension.swift; sourceTree = "<group>"; };
+		OBJ_34 /* XMLDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLDecoder.swift; sourceTree = "<group>"; };
+		OBJ_35 /* XMLDecodingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLDecodingStorage.swift; sourceTree = "<group>"; };
+		OBJ_36 /* XMLKeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLKeyedDecodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_37 /* XMLUnkeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLUnkeyedDecodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_39 /* EncodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingErrorExtension.swift; sourceTree = "<group>"; };
+		OBJ_40 /* XMLEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLEncoder.swift; sourceTree = "<group>"; };
+		OBJ_41 /* XMLEncodingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLEncodingStorage.swift; sourceTree = "<group>"; };
+		OBJ_42 /* XMLReferencingEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLReferencingEncoder.swift; sourceTree = "<group>"; };
+		OBJ_43 /* ISO8601DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISO8601DateFormatter.swift; sourceTree = "<group>"; };
+		OBJ_44 /* XMLKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLKey.swift; sourceTree = "<group>"; };
+		OBJ_45 /* XMLStackParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLStackParser.swift; sourceTree = "<group>"; };
+		OBJ_46 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/maxd/Documents/CoreXLSX/.build/checkouts/XMLCoder.git--8189013463900790701/Package.swift"; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		OBJ_9 /* CoreXLSX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSX.swift; sourceTree = "<group>"; };
+		OBJ_8 /* Package.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Package.xcconfig; sourceTree = "<group>"; };
 		"XMLCoder::XMLCoder::Product" /* XMLCoder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = XMLCoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ZIPFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		OBJ_106 /* Frameworks */ = {
+		OBJ_108 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_124 /* Frameworks */ = {
+		OBJ_126 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_58 /* Frameworks */ = {
+		OBJ_60 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_59 /* ZIPFoundation.framework in Frameworks */,
-				OBJ_60 /* XMLCoder.framework in Frameworks */,
+				OBJ_61 /* ZIPFoundation.framework in Frameworks */,
+				OBJ_62 /* XMLCoder.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_83 /* Frameworks */ = {
+		OBJ_85 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_84 /* CoreXLSX.framework in Frameworks */,
-				OBJ_85 /* ZIPFoundation.framework in Frameworks */,
-				OBJ_86 /* XMLCoder.framework in Frameworks */,
+				OBJ_86 /* CoreXLSX.framework in Frameworks */,
+				OBJ_87 /* ZIPFoundation.framework in Frameworks */,
+				OBJ_88 /* XMLCoder.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		OBJ_12 /* Tests */ = {
+		OBJ_10 /* CoreXLSX */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_13 /* CoreXLSXTests */,
+				OBJ_11 /* CoreXLSX.swift */,
+				OBJ_12 /* Relationships.swift */,
+				OBJ_13 /* Worksheet.swift */,
+			);
+			name = CoreXLSX;
+			path = Sources/CoreXLSX;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_14 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_15 /* CoreXLSXTests */,
 			);
 			name = Tests;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_13 /* CoreXLSXTests */ = {
+		OBJ_15 /* CoreXLSXTests */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_14 /* CoreXLSXTests.swift */,
-				OBJ_15 /* XCTestManifests.swift */,
+				OBJ_16 /* CoreXLSXTests.swift */,
+				OBJ_17 /* XCTestManifests.swift */,
 			);
 			name = CoreXLSXTests;
 			path = Tests/CoreXLSXTests;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_17 /* Dependencies */ = {
+		OBJ_19 /* Dependencies */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_18 /* ZIPFoundation 0.9.6 */,
-				OBJ_28 /* XMLCoder 0.1.0 */,
+				OBJ_20 /* ZIPFoundation 0.9.6 */,
+				OBJ_30 /* XMLCoder 0.1.0 */,
 			);
 			name = Dependencies;
 			sourceTree = "<group>";
 		};
-		OBJ_18 /* ZIPFoundation 0.9.6 */ = {
+		OBJ_20 /* ZIPFoundation 0.9.6 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_19 /* ZIPFoundation */,
-				OBJ_27 /* Package.swift */,
+				OBJ_21 /* ZIPFoundation */,
+				OBJ_29 /* Package.swift */,
 			);
 			name = "ZIPFoundation 0.9.6";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_19 /* ZIPFoundation */ = {
+		OBJ_21 /* ZIPFoundation */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_20 /* Archive+Reading.swift */,
-				OBJ_21 /* Archive+Writing.swift */,
-				OBJ_22 /* Archive.swift */,
-				OBJ_23 /* Data+Compression.swift */,
-				OBJ_24 /* Data+Serialization.swift */,
-				OBJ_25 /* Entry.swift */,
-				OBJ_26 /* FileManager+ZIP.swift */,
+				OBJ_22 /* Archive+Reading.swift */,
+				OBJ_23 /* Archive+Writing.swift */,
+				OBJ_24 /* Archive.swift */,
+				OBJ_25 /* Data+Compression.swift */,
+				OBJ_26 /* Data+Serialization.swift */,
+				OBJ_27 /* Entry.swift */,
+				OBJ_28 /* FileManager+ZIP.swift */,
 			);
 			name = ZIPFoundation;
-			path = ".build/checkouts/ZIPFoundation.git--2631978234166896080/Sources/ZIPFoundation";
+			path = ".build/checkouts/ZIPFoundation.git-1553630773966528904/Sources/ZIPFoundation";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_28 /* XMLCoder 0.1.0 */ = {
+		OBJ_30 /* XMLCoder 0.1.0 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_29 /* XMLCoder */,
-				OBJ_44 /* Package.swift */,
+				OBJ_31 /* XMLCoder */,
+				OBJ_46 /* Package.swift */,
 			);
 			name = "XMLCoder 0.1.0";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_29 /* XMLCoder */ = {
+		OBJ_31 /* XMLCoder */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_30 /* Decoder */,
-				OBJ_36 /* Encoder */,
-				OBJ_41 /* ISO8601DateFormatter.swift */,
-				OBJ_42 /* XMLKey.swift */,
-				OBJ_43 /* XMLStackParser.swift */,
+				OBJ_32 /* Decoder */,
+				OBJ_38 /* Encoder */,
+				OBJ_43 /* ISO8601DateFormatter.swift */,
+				OBJ_44 /* XMLKey.swift */,
+				OBJ_45 /* XMLStackParser.swift */,
 			);
 			name = XMLCoder;
-			path = ".build/checkouts/XMLCoder.git--2466284176948894372/Sources/XMLCoder";
+			path = ".build/checkouts/XMLCoder.git--8189013463900790701/Sources/XMLCoder";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_30 /* Decoder */ = {
+		OBJ_32 /* Decoder */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_31 /* DecodingErrorExtension.swift */,
-				OBJ_32 /* XMLDecoder.swift */,
-				OBJ_33 /* XMLDecodingStorage.swift */,
-				OBJ_34 /* XMLKeyedDecodingContainer.swift */,
-				OBJ_35 /* XMLUnkeyedDecodingContainer.swift */,
+				OBJ_33 /* DecodingErrorExtension.swift */,
+				OBJ_34 /* XMLDecoder.swift */,
+				OBJ_35 /* XMLDecodingStorage.swift */,
+				OBJ_36 /* XMLKeyedDecodingContainer.swift */,
+				OBJ_37 /* XMLUnkeyedDecodingContainer.swift */,
 			);
 			path = Decoder;
 			sourceTree = "<group>";
 		};
-		OBJ_36 /* Encoder */ = {
+		OBJ_38 /* Encoder */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_37 /* EncodingErrorExtension.swift */,
-				OBJ_38 /* XMLEncoder.swift */,
-				OBJ_39 /* XMLEncodingStorage.swift */,
-				OBJ_40 /* XMLReferencingEncoder.swift */,
+				OBJ_39 /* EncodingErrorExtension.swift */,
+				OBJ_40 /* XMLEncoder.swift */,
+				OBJ_41 /* XMLEncodingStorage.swift */,
+				OBJ_42 /* XMLReferencingEncoder.swift */,
 			);
 			path = Encoder;
 			sourceTree = "<group>";
 		};
-		OBJ_45 /* Products */ = {
+		OBJ_47 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				"ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */,
-				"XMLCoder::XMLCoder::Product" /* XMLCoder.framework */,
 				"CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */,
+				"XMLCoder::XMLCoder::Product" /* XMLCoder.framework */,
+				"ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */,
 				"CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */,
 			);
 			name = Products;
@@ -284,37 +294,33 @@
 		OBJ_5 /*  */ = {
 			isa = PBXGroup;
 			children = (
-				D1B8A6F921983DB800605F6D /* CoreXLSX.podspec */,
-				D1B8A6F821983DB800605F6D /* README.md */,
 				OBJ_6 /* Package.swift */,
-				OBJ_7 /* Sources */,
-				OBJ_12 /* Tests */,
-				OBJ_16 /* Example */,
-				OBJ_17 /* Dependencies */,
-				OBJ_45 /* Products */,
+				OBJ_7 /* Configs */,
+				OBJ_9 /* Sources */,
+				OBJ_14 /* Tests */,
+				OBJ_18 /* Example */,
+				OBJ_19 /* Dependencies */,
+				OBJ_47 /* Products */,
 			);
 			indentWidth = 2;
 			name = "";
 			sourceTree = "<group>";
 			tabWidth = 2;
 		};
-		OBJ_7 /* Sources */ = {
+		OBJ_7 /* Configs */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_8 /* CoreXLSX */,
+				OBJ_8 /* Package.xcconfig */,
+			);
+			name = Configs;
+			sourceTree = "<group>";
+		};
+		OBJ_9 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_10 /* CoreXLSX */,
 			);
 			name = Sources;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_8 /* CoreXLSX */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_9 /* CoreXLSX.swift */,
-				OBJ_10 /* Relationships.swift */,
-				OBJ_11 /* Worksheet.swift */,
-			);
-			name = CoreXLSX;
-			path = Sources/CoreXLSX;
 			sourceTree = SOURCE_ROOT;
 		};
 /* End PBXGroup section */
@@ -322,16 +328,16 @@
 /* Begin PBXNativeTarget section */
 		"CoreXLSX::CoreXLSX" /* CoreXLSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_51 /* Build configuration list for PBXNativeTarget "CoreXLSX" */;
+			buildConfigurationList = OBJ_53 /* Build configuration list for PBXNativeTarget "CoreXLSX" */;
 			buildPhases = (
-				OBJ_54 /* Sources */,
-				OBJ_58 /* Frameworks */,
+				OBJ_56 /* Sources */,
+				OBJ_60 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_61 /* PBXTargetDependency */,
 				OBJ_63 /* PBXTargetDependency */,
+				OBJ_65 /* PBXTargetDependency */,
 			);
 			name = CoreXLSX;
 			productName = CoreXLSX;
@@ -340,17 +346,17 @@
 		};
 		"CoreXLSX::CoreXLSXTests" /* CoreXLSXTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_77 /* Build configuration list for PBXNativeTarget "CoreXLSXTests" */;
+			buildConfigurationList = OBJ_79 /* Build configuration list for PBXNativeTarget "CoreXLSXTests" */;
 			buildPhases = (
-				OBJ_80 /* Sources */,
-				OBJ_83 /* Frameworks */,
+				OBJ_82 /* Sources */,
+				OBJ_85 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_87 /* PBXTargetDependency */,
-				OBJ_88 /* PBXTargetDependency */,
 				OBJ_89 /* PBXTargetDependency */,
+				OBJ_90 /* PBXTargetDependency */,
+				OBJ_91 /* PBXTargetDependency */,
 			);
 			name = CoreXLSXTests;
 			productName = CoreXLSXTests;
@@ -359,9 +365,9 @@
 		};
 		"CoreXLSX::SwiftPMPackageDescription" /* CoreXLSXPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_66 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */;
+			buildConfigurationList = OBJ_68 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */;
 			buildPhases = (
-				OBJ_69 /* Sources */,
+				OBJ_71 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -373,9 +379,9 @@
 		};
 		"XMLCoder::SwiftPMPackageDescription" /* XMLCoderPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_108 /* Build configuration list for PBXNativeTarget "XMLCoderPackageDescription" */;
+			buildConfigurationList = OBJ_110 /* Build configuration list for PBXNativeTarget "XMLCoderPackageDescription" */;
 			buildPhases = (
-				OBJ_111 /* Sources */,
+				OBJ_113 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -387,10 +393,10 @@
 		};
 		"XMLCoder::XMLCoder" /* XMLCoder */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_90 /* Build configuration list for PBXNativeTarget "XMLCoder" */;
+			buildConfigurationList = OBJ_92 /* Build configuration list for PBXNativeTarget "XMLCoder" */;
 			buildPhases = (
-				OBJ_93 /* Sources */,
-				OBJ_106 /* Frameworks */,
+				OBJ_95 /* Sources */,
+				OBJ_108 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -403,9 +409,9 @@
 		};
 		"ZIPFoundation::SwiftPMPackageDescription" /* ZIPFoundationPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_126 /* Build configuration list for PBXNativeTarget "ZIPFoundationPackageDescription" */;
+			buildConfigurationList = OBJ_128 /* Build configuration list for PBXNativeTarget "ZIPFoundationPackageDescription" */;
 			buildPhases = (
-				OBJ_129 /* Sources */,
+				OBJ_131 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -417,10 +423,10 @@
 		};
 		"ZIPFoundation::ZIPFoundation" /* ZIPFoundation */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_113 /* Build configuration list for PBXNativeTarget "ZIPFoundation" */;
+			buildConfigurationList = OBJ_115 /* Build configuration list for PBXNativeTarget "ZIPFoundation" */;
 			buildPhases = (
-				OBJ_116 /* Sources */,
-				OBJ_124 /* Frameworks */,
+				OBJ_118 /* Sources */,
+				OBJ_126 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -440,14 +446,14 @@
 				LastUpgradeCheck = 9999;
 			};
 			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "CoreXLSX" */;
-			compatibilityVersion = "Xcode 10.0";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
 			mainGroup = OBJ_5 /*  */;
-			productRefGroup = OBJ_45 /* Products */;
+			productRefGroup = OBJ_47 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -464,119 +470,119 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		OBJ_111 /* Sources */ = {
+		OBJ_113 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_112 /* Package.swift in Sources */,
+				OBJ_114 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_116 /* Sources */ = {
+		OBJ_118 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_117 /* Archive+Reading.swift in Sources */,
-				OBJ_118 /* Archive+Writing.swift in Sources */,
-				OBJ_119 /* Archive.swift in Sources */,
-				OBJ_120 /* Data+Compression.swift in Sources */,
-				OBJ_121 /* Data+Serialization.swift in Sources */,
-				OBJ_122 /* Entry.swift in Sources */,
-				OBJ_123 /* FileManager+ZIP.swift in Sources */,
+				OBJ_119 /* Archive+Reading.swift in Sources */,
+				OBJ_120 /* Archive+Writing.swift in Sources */,
+				OBJ_121 /* Archive.swift in Sources */,
+				OBJ_122 /* Data+Compression.swift in Sources */,
+				OBJ_123 /* Data+Serialization.swift in Sources */,
+				OBJ_124 /* Entry.swift in Sources */,
+				OBJ_125 /* FileManager+ZIP.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_129 /* Sources */ = {
+		OBJ_131 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_130 /* Package.swift in Sources */,
+				OBJ_132 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_54 /* Sources */ = {
+		OBJ_56 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_55 /* CoreXLSX.swift in Sources */,
-				OBJ_56 /* Relationships.swift in Sources */,
-				OBJ_57 /* Worksheet.swift in Sources */,
+				OBJ_57 /* CoreXLSX.swift in Sources */,
+				OBJ_58 /* Relationships.swift in Sources */,
+				OBJ_59 /* Worksheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_69 /* Sources */ = {
+		OBJ_71 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_70 /* Package.swift in Sources */,
+				OBJ_72 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_80 /* Sources */ = {
+		OBJ_82 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_81 /* CoreXLSXTests.swift in Sources */,
-				OBJ_82 /* XCTestManifests.swift in Sources */,
+				OBJ_83 /* CoreXLSXTests.swift in Sources */,
+				OBJ_84 /* XCTestManifests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_93 /* Sources */ = {
+		OBJ_95 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_94 /* DecodingErrorExtension.swift in Sources */,
-				OBJ_95 /* XMLDecoder.swift in Sources */,
-				OBJ_96 /* XMLDecodingStorage.swift in Sources */,
-				OBJ_97 /* XMLKeyedDecodingContainer.swift in Sources */,
-				OBJ_98 /* XMLUnkeyedDecodingContainer.swift in Sources */,
-				OBJ_99 /* EncodingErrorExtension.swift in Sources */,
-				OBJ_100 /* XMLEncoder.swift in Sources */,
-				OBJ_101 /* XMLEncodingStorage.swift in Sources */,
-				OBJ_102 /* XMLReferencingEncoder.swift in Sources */,
-				OBJ_103 /* ISO8601DateFormatter.swift in Sources */,
-				OBJ_104 /* XMLKey.swift in Sources */,
-				OBJ_105 /* XMLStackParser.swift in Sources */,
+				OBJ_96 /* DecodingErrorExtension.swift in Sources */,
+				OBJ_97 /* XMLDecoder.swift in Sources */,
+				OBJ_98 /* XMLDecodingStorage.swift in Sources */,
+				OBJ_99 /* XMLKeyedDecodingContainer.swift in Sources */,
+				OBJ_100 /* XMLUnkeyedDecodingContainer.swift in Sources */,
+				OBJ_101 /* EncodingErrorExtension.swift in Sources */,
+				OBJ_102 /* XMLEncoder.swift in Sources */,
+				OBJ_103 /* XMLEncodingStorage.swift in Sources */,
+				OBJ_104 /* XMLReferencingEncoder.swift in Sources */,
+				OBJ_105 /* ISO8601DateFormatter.swift in Sources */,
+				OBJ_106 /* XMLKey.swift in Sources */,
+				OBJ_107 /* XMLStackParser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		OBJ_61 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "ZIPFoundation::ZIPFoundation" /* ZIPFoundation */;
-			targetProxy = D1B8A6F22198330900605F6D /* PBXContainerItemProxy */;
-		};
 		OBJ_63 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "XMLCoder::XMLCoder" /* XMLCoder */;
-			targetProxy = D1B8A6F32198330900605F6D /* PBXContainerItemProxy */;
+			target = "ZIPFoundation::ZIPFoundation" /* ZIPFoundation */;
+			targetProxy = D155EAEF219ADA9E00D4F47E /* PBXContainerItemProxy */;
 		};
-		OBJ_75 /* PBXTargetDependency */ = {
+		OBJ_65 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "XMLCoder::XMLCoder" /* XMLCoder */;
+			targetProxy = D155EAF0219ADA9E00D4F47E /* PBXContainerItemProxy */;
+		};
+		OBJ_77 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "CoreXLSX::CoreXLSXTests" /* CoreXLSXTests */;
-			targetProxy = D1B8A6F72198330A00605F6D /* PBXContainerItemProxy */;
-		};
-		OBJ_87 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "CoreXLSX::CoreXLSX" /* CoreXLSX */;
-			targetProxy = D1B8A6F42198330900605F6D /* PBXContainerItemProxy */;
-		};
-		OBJ_88 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "ZIPFoundation::ZIPFoundation" /* ZIPFoundation */;
-			targetProxy = D1B8A6F52198330900605F6D /* PBXContainerItemProxy */;
+			targetProxy = D155EAF4219ADA9E00D4F47E /* PBXContainerItemProxy */;
 		};
 		OBJ_89 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			target = "CoreXLSX::CoreXLSX" /* CoreXLSX */;
+			targetProxy = D155EAF1219ADA9E00D4F47E /* PBXContainerItemProxy */;
+		};
+		OBJ_90 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "ZIPFoundation::ZIPFoundation" /* ZIPFoundation */;
+			targetProxy = D155EAF2219ADA9E00D4F47E /* PBXContainerItemProxy */;
+		};
+		OBJ_91 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
 			target = "XMLCoder::XMLCoder" /* XMLCoder */;
-			targetProxy = D1B8A6F62198330900605F6D /* PBXContainerItemProxy */;
+			targetProxy = D155EAF3219ADA9E00D4F47E /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		OBJ_109 /* Debug */ = {
+		OBJ_111 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
@@ -585,7 +591,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_110 /* Release */ = {
+		OBJ_112 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
@@ -594,8 +600,9 @@
 			};
 			name = Release;
 		};
-		OBJ_114 /* Debug */ = {
+		OBJ_116 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -604,10 +611,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/ZIPFoundation_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -621,8 +625,9 @@
 			};
 			name = Debug;
 		};
-		OBJ_115 /* Release */ = {
+		OBJ_117 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -631,10 +636,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/ZIPFoundation_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -648,7 +650,7 @@
 			};
 			name = Release;
 		};
-		OBJ_127 /* Debug */ = {
+		OBJ_129 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
@@ -657,7 +659,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_128 /* Release */ = {
+		OBJ_130 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
@@ -680,7 +682,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "-DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -701,20 +703,20 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_OPTIMIZATION_LEVEL = s;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_SWIFT_FLAGS = "-DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				USE_HEADERMAP = NO;
 			};
 			name = Release;
 		};
-		OBJ_52 /* Debug */ = {
+		OBJ_54 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -723,10 +725,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSX_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -740,8 +739,9 @@
 			};
 			name = Debug;
 		};
-		OBJ_53 /* Release */ = {
+		OBJ_55 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -750,10 +750,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSX_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -767,7 +764,7 @@
 			};
 			name = Release;
 		};
-		OBJ_67 /* Debug */ = {
+		OBJ_69 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
@@ -776,7 +773,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_68 /* Release */ = {
+		OBJ_70 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
@@ -785,20 +782,21 @@
 			};
 			name = Release;
 		};
-		OBJ_73 /* Debug */ = {
+		OBJ_75 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		OBJ_74 /* Release */ = {
+		OBJ_76 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		OBJ_78 /* Debug */ = {
+		OBJ_80 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
@@ -808,11 +806,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@loader_path/../Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -822,8 +816,9 @@
 			};
 			name = Debug;
 		};
-		OBJ_79 /* Release */ = {
+		OBJ_81 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
@@ -833,11 +828,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@loader_path/../Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -847,8 +838,9 @@
 			};
 			name = Release;
 		};
-		OBJ_91 /* Debug */ = {
+		OBJ_93 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -857,10 +849,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/XMLCoder_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -874,8 +863,9 @@
 			};
 			name = Debug;
 		};
-		OBJ_92 /* Release */ = {
+		OBJ_94 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -884,10 +874,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/XMLCoder_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -904,29 +891,29 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		OBJ_108 /* Build configuration list for PBXNativeTarget "XMLCoderPackageDescription" */ = {
+		OBJ_110 /* Build configuration list for PBXNativeTarget "XMLCoderPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_109 /* Debug */,
-				OBJ_110 /* Release */,
+				OBJ_111 /* Debug */,
+				OBJ_112 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_113 /* Build configuration list for PBXNativeTarget "ZIPFoundation" */ = {
+		OBJ_115 /* Build configuration list for PBXNativeTarget "ZIPFoundation" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_114 /* Debug */,
-				OBJ_115 /* Release */,
+				OBJ_116 /* Debug */,
+				OBJ_117 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_126 /* Build configuration list for PBXNativeTarget "ZIPFoundationPackageDescription" */ = {
+		OBJ_128 /* Build configuration list for PBXNativeTarget "ZIPFoundationPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_127 /* Debug */,
-				OBJ_128 /* Release */,
+				OBJ_129 /* Debug */,
+				OBJ_130 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -940,47 +927,47 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_51 /* Build configuration list for PBXNativeTarget "CoreXLSX" */ = {
+		OBJ_53 /* Build configuration list for PBXNativeTarget "CoreXLSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_52 /* Debug */,
-				OBJ_53 /* Release */,
+				OBJ_54 /* Debug */,
+				OBJ_55 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_66 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */ = {
+		OBJ_68 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_67 /* Debug */,
-				OBJ_68 /* Release */,
+				OBJ_69 /* Debug */,
+				OBJ_70 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_72 /* Build configuration list for PBXAggregateTarget "CoreXLSXPackageTests" */ = {
+		OBJ_74 /* Build configuration list for PBXAggregateTarget "CoreXLSXPackageTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_73 /* Debug */,
-				OBJ_74 /* Release */,
+				OBJ_75 /* Debug */,
+				OBJ_76 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_77 /* Build configuration list for PBXNativeTarget "CoreXLSXTests" */ = {
+		OBJ_79 /* Build configuration list for PBXNativeTarget "CoreXLSXTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_78 /* Debug */,
-				OBJ_79 /* Release */,
+				OBJ_80 /* Debug */,
+				OBJ_81 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_90 /* Build configuration list for PBXNativeTarget "XMLCoder" */ = {
+		OBJ_92 /* Build configuration list for PBXNativeTarget "XMLCoder" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_91 /* Debug */,
-				OBJ_92 /* Release */,
+				OBJ_93 /* Debug */,
+				OBJ_94 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Sources/CoreXLSX/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet.swift
@@ -12,10 +12,25 @@ public struct Worksheet: Codable {
   public let dimension: WorksheetDimension
   public let sheetViews: SheetViews
   public let sheetFormatPr: SheetFormatPr
-  // FIXME: rename this to `columns` before the next major release
-  public let cols: Cols
+  public let columns: Columns
+
+  @available(*, deprecated, renamed: "columns")
+  public var cols: Cols {
+    return columns
+  }
+
   public let sheetData: SheetData
   public let mergeCells: MergeCells?
+
+  enum CodingKeys: String, CodingKey {
+    case sheetPr
+    case dimension
+    case sheetViews
+    case sheetFormatPr
+    case columns = "cols"
+    case sheetData
+    case mergeCells
+  }
 }
 
 public struct SheetPr: Codable {
@@ -61,15 +76,21 @@ public struct SheetFormatPr: Codable {
   public let outlineLevelCol: String?
 }
 
-public struct Cols: Codable {
-  public let items: [Col]
+@available(*, deprecated, renamed: "Columns")
+public typealias Cols = Columns
+
+public struct Columns: Codable {
+  public let items: [Column]
 
   enum CodingKeys: String, CodingKey {
     case items = "col"
   }
 }
 
-public struct Col: Codable {
+@available(*, deprecated, renamed: "Column")
+public typealias Col = Column
+
+public struct Column: Codable {
   public let min: String
   public let max: String
   public let width: String
@@ -102,6 +123,12 @@ public struct Row: Codable {
 public struct Cell: Codable, Equatable {
   public let reference: String
   public let type: String?
+
+  /// Attribute "s" in a cell is an index into the styles table,
+  /// while the cell type "s" corresponds to the shared string table.
+  /// XMLCoder as version 0.1 can't distinguish between an attribute and a
+  /// node having the same name, so the property stays name `s` until
+  /// that's fixed.
   public let s: String?
   public let inlineString: InlineString?
   public let formula: String?
@@ -128,8 +155,16 @@ public struct MergeCells: Codable {
 }
 
 public struct MergeCell: Codable {
-  // FIXME: rename this to `reference` before the next major release
-  public let ref: String
+  public let reference: String
+
+  @available(*, deprecated, renamed: "reference")
+  public var ref: String {
+    return reference
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case reference = "ref"
+  }
 }
 
 public struct InlineString: Codable, Equatable {


### PR DESCRIPTION
Some properties on `Worksheet` and its descendants had obscure names, most of that is fixed now with old names marked as deprecated.