### PR TITLE
Add ColumnReference type with new API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: swift
 # podfile: Example/Podfile
 before_install:
 - gem install cocoapods --pre # Since Travis is not always on latest version
-- pod repo update
+# - pod repo update
 # - pod install --project-directory=Example
 script:
 - pod lib lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: swift
 # podfile: Example/Podfile
 before_install:
 - gem install cocoapods --pre # Since Travis is not always on latest version
-# - pod repo update
+- pod repo update
 # - pod install --project-directory=Example
 script:
 - pod lib lint

--- a/CoreXLSX.xcodeproj/project.pbxproj
+++ b/CoreXLSX.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		D123DC9D219B471D007F6E04 /* ColumnReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D123DC9C219B471D007F6E04 /* ColumnReference.swift */; };
 		D123DC9F219C29DD007F6E04 /* CellReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D123DC9E219C29DD007F6E04 /* CellReference.swift */; };
 		D15E8358219D7F0F00EB4544 /* RelationshipsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15E8357219D7F0F00EB4544 /* RelationshipsTests.swift */; };
+		D15E835A219D87B100EB4544 /* CellReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15E8359219D87B100EB4544 /* CellReferenceTests.swift */; };
 		OBJ_100 /* XMLUnkeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* XMLUnkeyedDecodingContainer.swift */; };
 		OBJ_101 /* EncodingErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* EncodingErrorExtension.swift */; };
 		OBJ_102 /* XMLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* XMLEncoder.swift */; };
@@ -112,6 +113,7 @@
 		D155EAF5219ADF9C00D4F47E /* CoreXLSX.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreXLSX.podspec; sourceTree = "<group>"; };
 		D155EAF6219ADF9C00D4F47E /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		D15E8357219D7F0F00EB4544 /* RelationshipsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipsTests.swift; sourceTree = "<group>"; };
+		D15E8359219D87B100EB4544 /* CellReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellReferenceTests.swift; sourceTree = "<group>"; };
 		OBJ_11 /* CoreXLSX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSX.swift; sourceTree = "<group>"; };
 		OBJ_12 /* Relationships.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Relationships.swift; sourceTree = "<group>"; };
 		OBJ_13 /* Worksheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Worksheet.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 				OBJ_16 /* CoreXLSXTests.swift */,
 				OBJ_17 /* XCTestManifests.swift */,
 				D15E8357219D7F0F00EB4544 /* RelationshipsTests.swift */,
+				D15E8359219D87B100EB4544 /* CellReferenceTests.swift */,
 			);
 			name = CoreXLSXTests;
 			path = Tests/CoreXLSXTests;
@@ -539,6 +542,7 @@
 			buildActionMask = 0;
 			files = (
 				OBJ_83 /* CoreXLSXTests.swift in Sources */,
+				D15E835A219D87B100EB4544 /* CellReferenceTests.swift in Sources */,
 				OBJ_84 /* XCTestManifests.swift in Sources */,
 				D15E8358219D7F0F00EB4544 /* RelationshipsTests.swift in Sources */,
 			);

--- a/CoreXLSX.xcodeproj/project.pbxproj
+++ b/CoreXLSX.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* Begin PBXBuildFile section */
 		D123DC9D219B471D007F6E04 /* ColumnReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D123DC9C219B471D007F6E04 /* ColumnReference.swift */; };
 		D123DC9F219C29DD007F6E04 /* CellReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D123DC9E219C29DD007F6E04 /* CellReference.swift */; };
+		D15E8358219D7F0F00EB4544 /* RelationshipsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15E8357219D7F0F00EB4544 /* RelationshipsTests.swift */; };
 		OBJ_100 /* XMLUnkeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* XMLUnkeyedDecodingContainer.swift */; };
 		OBJ_101 /* EncodingErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* EncodingErrorExtension.swift */; };
 		OBJ_102 /* XMLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* XMLEncoder.swift */; };
@@ -105,11 +106,12 @@
 /* Begin PBXFileReference section */
 		"CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CoreXLSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = CoreXLSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D123DCA0219C35BA007F6E04 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		D123DC9C219B471D007F6E04 /* ColumnReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnReference.swift; sourceTree = "<group>"; };
 		D123DC9E219C29DD007F6E04 /* CellReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellReference.swift; sourceTree = "<group>"; };
+		D123DCA0219C35BA007F6E04 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		D155EAF5219ADF9C00D4F47E /* CoreXLSX.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreXLSX.podspec; sourceTree = "<group>"; };
 		D155EAF6219ADF9C00D4F47E /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		D15E8357219D7F0F00EB4544 /* RelationshipsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipsTests.swift; sourceTree = "<group>"; };
 		OBJ_11 /* CoreXLSX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSX.swift; sourceTree = "<group>"; };
 		OBJ_12 /* Relationships.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Relationships.swift; sourceTree = "<group>"; };
 		OBJ_13 /* Worksheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Worksheet.swift; sourceTree = "<group>"; };
@@ -206,6 +208,7 @@
 			children = (
 				OBJ_16 /* CoreXLSXTests.swift */,
 				OBJ_17 /* XCTestManifests.swift */,
+				D15E8357219D7F0F00EB4544 /* RelationshipsTests.swift */,
 			);
 			name = CoreXLSXTests;
 			path = Tests/CoreXLSXTests;
@@ -537,6 +540,7 @@
 			files = (
 				OBJ_83 /* CoreXLSXTests.swift in Sources */,
 				OBJ_84 /* XCTestManifests.swift in Sources */,
+				D15E8358219D7F0F00EB4544 /* RelationshipsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CoreXLSX.xcodeproj/project.pbxproj
+++ b/CoreXLSX.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		D123DC9D219B471D007F6E04 /* ColumnReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D123DC9C219B471D007F6E04 /* ColumnReference.swift */; };
+		D123DC9F219C29DD007F6E04 /* CellReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D123DC9E219C29DD007F6E04 /* CellReference.swift */; };
 		OBJ_100 /* XMLUnkeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* XMLUnkeyedDecodingContainer.swift */; };
 		OBJ_101 /* EncodingErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* EncodingErrorExtension.swift */; };
 		OBJ_102 /* XMLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* XMLEncoder.swift */; };
@@ -104,6 +106,8 @@
 		"CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CoreXLSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = CoreXLSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D123DCA0219C35BA007F6E04 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		D123DC9C219B471D007F6E04 /* ColumnReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnReference.swift; sourceTree = "<group>"; };
+		D123DC9E219C29DD007F6E04 /* CellReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellReference.swift; sourceTree = "<group>"; };
 		D155EAF5219ADF9C00D4F47E /* CoreXLSX.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreXLSX.podspec; sourceTree = "<group>"; };
 		D155EAF6219ADF9C00D4F47E /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_11 /* CoreXLSX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSX.swift; sourceTree = "<group>"; };
@@ -182,6 +186,8 @@
 				OBJ_11 /* CoreXLSX.swift */,
 				OBJ_12 /* Relationships.swift */,
 				OBJ_13 /* Worksheet.swift */,
+				D123DC9C219B471D007F6E04 /* ColumnReference.swift */,
+				D123DC9E219C29DD007F6E04 /* CellReference.swift */,
 			);
 			name = CoreXLSX;
 			path = Sources/CoreXLSX;
@@ -510,6 +516,8 @@
 			buildActionMask = 0;
 			files = (
 				OBJ_57 /* CoreXLSX.swift in Sources */,
+				D123DC9D219B471D007F6E04 /* ColumnReference.swift in Sources */,
+				D123DC9F219C29DD007F6E04 /* CellReference.swift in Sources */,
 				OBJ_58 /* Relationships.swift in Sources */,
 				OBJ_59 /* Worksheet.swift in Sources */,
 			);

--- a/Sources/CoreXLSX/CellReference.swift
+++ b/Sources/CoreXLSX/CellReference.swift
@@ -34,12 +34,19 @@ extension CellReference: Decodable {
     let container = try decoder.singleValueContainer()
     let reference = try container.decode(String.self)
 
-    guard let separatorIndex = reference.lastIndex(where: {
+    guard let lastLetterIndex = reference.lastIndex(where: {
       $0.unicodeScalars.allSatisfy {
         ColumnReference.allowedCharacters.contains($0)
+
       }
-    }),
-    let column = ColumnReference(reference.prefix(upTo: separatorIndex)) else {
+    }) else {
+      throw CoreXLSXError.invalidCellReference
+    }
+
+    let separatorIndex = reference.index(after: lastLetterIndex)
+
+    guard let column =
+    ColumnReference(reference.prefix(upTo: separatorIndex)) else {
       throw CoreXLSXError.invalidCellReference
     }
 

--- a/Sources/CoreXLSX/CellReference.swift
+++ b/Sources/CoreXLSX/CellReference.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public struct CellReference {
   public let column: ColumnReference
-  public let row: Int
+  public let row: UInt
 
-  public init(_ column: ColumnReference, _ row: Int) {
+  public init(_ column: ColumnReference, _ row: UInt) {
     self.column = column
     self.row = row
   }
@@ -50,7 +50,7 @@ extension CellReference: Decodable {
       throw CoreXLSXError.invalidCellReference
     }
 
-    guard let cell = Int(reference.suffix(from: separatorIndex)) else {
+    guard let cell = UInt(reference.suffix(from: separatorIndex)) else {
       throw CoreXLSXError.invalidCellReference
     }
 

--- a/Sources/CoreXLSX/CellReference.swift
+++ b/Sources/CoreXLSX/CellReference.swift
@@ -1,0 +1,52 @@
+//
+//  CellReference.swift
+//  CoreXLSX
+//
+//  Created by Max Desiatov on 14/11/2018.
+//
+
+import Foundation
+
+struct CellReference {
+  let column: ColumnReference
+  let row: Int
+
+  init(_ column: ColumnReference, _ row: Int) {
+    self.column = column
+    self.row = row
+  }
+}
+
+extension CellReference: CustomStringConvertible {
+  var description: String {
+    return "\(column)\(row)"
+  }
+}
+
+extension CellReference: Decodable {
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let reference = try container.decode(String.self)
+
+    guard let separatorIndex = reference.lastIndex(where: {
+      $0.unicodeScalars.allSatisfy {
+        ColumnReference.allowedCharacters.contains($0)
+      }
+    }) else { throw CoreXLSXError.invalidCellReference }
+
+    let column = reference.prefix(upTo: separatorIndex)
+
+    guard let cell = Int(reference.suffix(from: separatorIndex)) else {
+      throw CoreXLSXError.invalidCellReference
+    }
+
+    self.init(ColumnReference(String(column)), cell)
+  }
+}
+
+extension CellReference: Encodable {
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(description)
+  }
+}

--- a/Sources/CoreXLSX/CellReference.swift
+++ b/Sources/CoreXLSX/CellReference.swift
@@ -7,24 +7,30 @@
 
 import Foundation
 
-struct CellReference {
-  let column: ColumnReference
-  let row: Int
+public struct CellReference {
+  public let column: ColumnReference
+  public let row: Int
 
-  init(_ column: ColumnReference, _ row: Int) {
+  public init(_ column: ColumnReference, _ row: Int) {
     self.column = column
     self.row = row
   }
 }
 
+extension CellReference: Equatable {
+  public static func == (lhs: CellReference, rhs: CellReference) -> Bool {
+    return lhs.column == rhs.column && lhs.row == rhs.row
+  }
+}
+
 extension CellReference: CustomStringConvertible {
-  var description: String {
+  public var description: String {
     return "\(column)\(row)"
   }
 }
 
 extension CellReference: Decodable {
-  init(from decoder: Decoder) throws {
+  public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
     let reference = try container.decode(String.self)
 
@@ -32,20 +38,21 @@ extension CellReference: Decodable {
       $0.unicodeScalars.allSatisfy {
         ColumnReference.allowedCharacters.contains($0)
       }
-    }) else { throw CoreXLSXError.invalidCellReference }
-
-    let column = reference.prefix(upTo: separatorIndex)
+    }),
+    let column = ColumnReference(reference.prefix(upTo: separatorIndex)) else {
+      throw CoreXLSXError.invalidCellReference
+    }
 
     guard let cell = Int(reference.suffix(from: separatorIndex)) else {
       throw CoreXLSXError.invalidCellReference
     }
 
-    self.init(ColumnReference(String(column)), cell)
+    self.init(column, cell)
   }
 }
 
 extension CellReference: Encodable {
-  func encode(to encoder: Encoder) throws {
+  public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
     try container.encode(description)
   }

--- a/Sources/CoreXLSX/ColumnReference.swift
+++ b/Sources/CoreXLSX/ColumnReference.swift
@@ -1,0 +1,40 @@
+//
+//  Reference.swift
+//  CoreXLSX
+//
+//  Created by Max Desiatov on 13/11/2018.
+//
+
+import Foundation
+
+struct ColumnReference {
+  let value: String
+
+  init(_ value: String) {
+    self.value = value.uppercased()
+  }
+
+  static let allowedCharacters = CharacterSet.letters
+}
+
+extension ColumnReference: CustomStringConvertible {
+  var description: String {
+    return "\(value)"
+  }
+}
+
+extension ColumnReference: Comparable {
+  public static func < (lhs: ColumnReference, rhs: ColumnReference) -> Bool {
+    return lhs.value < rhs.value
+  }
+
+  public static func == (lhs: ColumnReference, rhs: ColumnReference) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
+
+extension ColumnReference: ExpressibleByStringLiteral {
+  init(stringLiteral: String) {
+    self.init(stringLiteral)
+  }
+}

--- a/Sources/CoreXLSX/ColumnReference.swift
+++ b/Sources/CoreXLSX/ColumnReference.swift
@@ -7,10 +7,18 @@
 
 import Foundation
 
-struct ColumnReference {
-  let value: String
+public struct ColumnReference {
+  public let value: String
 
-  init(_ value: String) {
+  public init?(_ value: String) {
+    self.init(Substring(value))
+  }
+
+  public init?(_ value: Substring) {
+    guard value.unicodeScalars.allSatisfy({
+      ColumnReference.allowedCharacters.contains($0)
+    }) else { return nil }
+
     self.value = value.uppercased()
   }
 
@@ -18,7 +26,7 @@ struct ColumnReference {
 }
 
 extension ColumnReference: CustomStringConvertible {
-  var description: String {
+  public var description: String {
     return "\(value)"
   }
 }
@@ -30,11 +38,5 @@ extension ColumnReference: Comparable {
 
   public static func == (lhs: ColumnReference, rhs: ColumnReference) -> Bool {
     return lhs.value == rhs.value
-  }
-}
-
-extension ColumnReference: ExpressibleByStringLiteral {
-  init(stringLiteral: String) {
-    self.init(stringLiteral)
   }
 }

--- a/Sources/CoreXLSX/ColumnReference.swift
+++ b/Sources/CoreXLSX/ColumnReference.swift
@@ -15,14 +15,18 @@ public struct ColumnReference {
   }
 
   public init?(_ value: Substring) {
-    guard value.unicodeScalars.allSatisfy({
+    guard !value.isEmpty, value.unicodeScalars.allSatisfy({
       ColumnReference.allowedCharacters.contains($0)
     }) else { return nil }
 
     self.value = value.uppercased()
   }
 
-  static let allowedCharacters = CharacterSet.letters
+  static let firstAllowedCharacter = "A" as UnicodeScalar
+  static let lastAllowedCharacter = "Z" as UnicodeScalar
+
+  static let allowedCharacters =
+    CharacterSet(charactersIn: firstAllowedCharacter...lastAllowedCharacter)
 }
 
 extension ColumnReference: CustomStringConvertible {

--- a/Sources/CoreXLSX/CoreXLSX.swift
+++ b/Sources/CoreXLSX/CoreXLSX.swift
@@ -88,6 +88,7 @@ public struct XLSXFile {
   }
 
   /// Return all cells that are contained in a given worksheet and set of rows.
+  @available(*, deprecated, renamed: "Worksheet.cells(atRows:)")
   public func cellsInWorksheet(at path: String, rows: [Int]) throws
   -> [Cell] {
     let ws = try parseWorksheet(at: path)
@@ -97,27 +98,10 @@ public struct XLSXFile {
   }
 
   /// Return all cells that are contained in a given worksheet and set of
-  /// columns.
-  public func cellsInWorksheet(at path: String,
-                               columns: [ColumnReference]) throws -> [Cell] {
-      let ws = try parseWorksheet(at: path)
-
-      return ws.sheetData.rows.map {
-        let rowReference = $0.reference
-        let targetReferences = columns.map {
-          CellReference($0, rowReference)
-        }
-        return $0.cells.filter { targetReferences.contains($0.reference) }
-      }
-      .reduce([]) { $0 + $1 }
-  }
-
-  /// Return all cells that are contained in a given worksheet and set of
   /// columns. This overloaded version is deprecated, you should pass
   /// an array of `ColumnReference` values as `columns` instead of an array
   /// of `String`s.
-  @available(*, deprecated,
-  message: "use overloaded version with `[ColumnReference]` argument instead")
+  @available(*, deprecated, renamed: "Worksheet.cells(atColumns:)")
   public func cellsInWorksheet(at path: String, columns: [String]) throws
   -> [Cell] {
     let ws = try parseWorksheet(at: path)

--- a/Sources/CoreXLSX/CoreXLSX.swift
+++ b/Sources/CoreXLSX/CoreXLSX.swift
@@ -98,13 +98,37 @@ public struct XLSXFile {
 
   /// Return all cells that are contained in a given worksheet and set of
   /// columns.
+  public func cellsInWorksheet(at path: String,
+                               columns: [ColumnReference]) throws -> [Cell] {
+      let ws = try parseWorksheet(at: path)
+
+      return ws.sheetData.rows.map {
+        let rowReference = $0.reference
+        let targetReferences = columns.map {
+          CellReference($0, rowReference)
+        }
+        return $0.cells.filter { targetReferences.contains($0.reference) }
+      }
+      .reduce([]) { $0 + $1 }
+  }
+
+  /// Return all cells that are contained in a given worksheet and set of
+  /// columns. This overloaded version is deprecated, you should pass
+  /// an array of `ColumnReference` values as `columns` instead of an array
+  /// of `String`s.
+  @available(*, deprecated,
+  message: "use overloaded version with `[ColumnReference]` argument instead")
   public func cellsInWorksheet(at path: String, columns: [String]) throws
   -> [Cell] {
     let ws = try parseWorksheet(at: path)
 
     return ws.sheetData.rows.map {
       let rowReference = $0.reference
-      let targetReferences = columns.map { "\($0)\(rowReference)" }
+      let targetReferences = columns.compactMap {
+      (c: String) -> CellReference? in
+        guard let columnReference = ColumnReference(c) else { return nil }
+        return CellReference(columnReference, rowReference)
+      }
       return $0.cells.filter { targetReferences.contains($0.reference) }
     }
     .reduce([]) { $0 + $1 }

--- a/Sources/CoreXLSX/CoreXLSX.swift
+++ b/Sources/CoreXLSX/CoreXLSX.swift
@@ -93,7 +93,7 @@ public struct XLSXFile {
   -> [Cell] {
     let ws = try parseWorksheet(at: path)
 
-    return ws.sheetData.rows.filter { rows.contains($0.reference) }
+    return ws.sheetData.rows.filter { rows.contains(Int($0.reference)) }
       .reduce([]) { $0 + $1.cells }
   }
 

--- a/Sources/CoreXLSX/CoreXLSX.swift
+++ b/Sources/CoreXLSX/CoreXLSX.swift
@@ -2,8 +2,12 @@ import Foundation
 import ZIPFoundation
 import XMLCoder
 
-public enum XLSXReaderError: Error {
+@available(*, deprecated, renamed: "CoreXLSXError")
+public typealias XLSXReaderError = CoreXLSXError
+
+public enum CoreXLSXError: Error {
   case archiveEntryNotFound
+  case invalidCellReference
 }
 
 public struct XLSXFile {
@@ -29,7 +33,7 @@ public struct XLSXFile {
   /// an instance of `type`.
   func parseEntry<T: Decodable>(_ path: String, _ type: T.Type) throws -> T {
     guard let entry = archive[path] else {
-      throw XLSXReaderError.archiveEntryNotFound
+      throw CoreXLSXError.archiveEntryNotFound
     }
 
     var result: T?

--- a/Sources/CoreXLSX/Relationships.swift
+++ b/Sources/CoreXLSX/Relationships.swift
@@ -15,7 +15,7 @@ struct Relationships: Codable {
   }
 }
 
-struct Relationship: Codable {
+struct Relationship: Codable, Equatable {
   enum SchemaType: String, Codable {
     case officeDocument = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
     case extendedProperties = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties"

--- a/Sources/CoreXLSX/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet.swift
@@ -98,7 +98,7 @@ public struct SheetFormatPr: Codable {
 @available(*, deprecated, renamed: "Columns")
 public typealias Cols = Columns
 
-public struct Columns: Codable {
+public struct Columns: Codable, Equatable {
   public let items: [Column]
 
   enum CodingKeys: String, CodingKey {
@@ -109,7 +109,7 @@ public struct Columns: Codable {
 @available(*, deprecated, renamed: "Column")
 public typealias Col = Column
 
-public struct Column: Codable {
+public struct Column: Codable, Equatable {
   public let min: String
   public let max: String
   public let width: String

--- a/Sources/CoreXLSX/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet.swift
@@ -121,7 +121,7 @@ public struct Row: Codable {
 }
 
 public struct Cell: Codable, Equatable {
-  public let reference: String
+  public let reference: CellReference
   public let type: String?
 
   /// Attribute "s" in a cell is an index into the styles table,
@@ -155,6 +155,7 @@ public struct MergeCells: Codable {
 }
 
 public struct MergeCell: Codable {
+  /// A reference of format "A1:F1"
   public let reference: String
 
   @available(*, deprecated, renamed: "reference")

--- a/Sources/CoreXLSX/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet.swift
@@ -31,6 +31,25 @@ public struct Worksheet: Codable {
     case sheetData
     case mergeCells
   }
+
+  /// Return all cells that are contained in a given worksheet and set of
+  /// columns.
+  public func cells(atColumns columns: [ColumnReference]) -> [Cell] {
+    return sheetData.rows.map {
+      let rowReference = $0.reference
+      let targetReferences = columns.map {
+        CellReference($0, rowReference)
+      }
+      return $0.cells.filter { targetReferences.contains($0.reference) }
+    }
+    .reduce([]) { $0 + $1 }
+  }
+
+  /// Return all cells that are contained in a given worksheet and set of rows.
+  public func cells(atRows rows: [Int]) -> [Cell] {
+    return sheetData.rows.filter { rows.contains($0.reference) }
+      .reduce([]) { $0 + $1.cells }
+  }
 }
 
 public struct SheetPr: Codable {

--- a/Sources/CoreXLSX/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet.swift
@@ -46,7 +46,7 @@ public struct Worksheet: Codable {
   }
 
   /// Return all cells that are contained in a given worksheet and set of rows.
-  public func cells(atRows rows: [Int]) -> [Cell] {
+  public func cells(atRows rows: [UInt]) -> [Cell] {
     return sheetData.rows.filter { rows.contains($0.reference) }
       .reduce([]) { $0 + $1.cells }
   }
@@ -126,7 +126,7 @@ public struct SheetData: Codable {
 }
 
 public struct Row: Codable {
-  public let reference: Int
+  public let reference: UInt
   public let ht: String?
   public let customHeight: String?
   public let cells: [Cell]

--- a/Tests/CoreXLSXTests/CellReferenceTests.swift
+++ b/Tests/CoreXLSXTests/CellReferenceTests.swift
@@ -17,21 +17,41 @@ private let exampleXML2 = """
 <Cell r="ZA47" />
 """.data(using: .utf8)!
 
+private let exampleXML3 = """
+<Cell r="kljsndfkvljdsfnjkvl" />
+""".data(using: .utf8)!
+
+
 final class CellReferenceTests: XCTestCase {
   private let decoder = XMLDecoder()
+  private let encoder = XMLEncoder()
 
   func testCellReference() {
     do {
       let c1 = try decoder.decode(Cell.self, from: exampleXML1)
+      let cr1 = CellReference(ColumnReference("A")!, 7)
+      XCTAssertEqual(cr1.description, "A7")
       XCTAssertEqual(c1,
-                     Cell(reference: CellReference(ColumnReference("A")!, 7),
+                     Cell(reference: cr1,
                           type: nil, s: nil, inlineString: nil, formula: nil,
                           value: nil))
+
       let c2 = try decoder.decode(Cell.self, from: exampleXML2)
+      let cr2 = CellReference(ColumnReference("ZA")!, 47)
+
+      XCTAssertThrowsError(try decoder.decode(Cell.self, from: exampleXML3))
+
+      XCTAssertEqual(cr2.description, "ZA47")
       XCTAssertEqual(c2,
-                     Cell(reference: CellReference(ColumnReference("ZA")!, 47),
+                     Cell(reference: cr2,
                      type: nil, s: nil, inlineString: nil, formula: nil,
                      value: nil))
+
+      let c1Encoded = try encoder.encode(c1, withRootKey: "Cell")
+      XCTAssertEqual(c1, try decoder.decode(Cell.self, from: c1Encoded))
+
+      let c2Encoded = try encoder.encode(c2, withRootKey: "Cell")
+      XCTAssertEqual(c2, try decoder.decode(Cell.self, from: c2Encoded))
 
     } catch {
       XCTAssert(false, "unexpected error \(error)")

--- a/Tests/CoreXLSXTests/CellReferenceTests.swift
+++ b/Tests/CoreXLSXTests/CellReferenceTests.swift
@@ -1,0 +1,62 @@
+//
+//  CellReferenceTests.swift
+//  CoreXLSXTests
+//
+//  Created by Max Desiatov on 15/11/2018.
+//
+
+import XCTest
+import XMLCoder
+@testable import CoreXLSX
+
+private let exampleXML1 = """
+<Cell r="A7" />
+""".data(using: .utf8)!
+
+private let exampleXML2 = """
+<Cell r="ZA47" />
+""".data(using: .utf8)!
+
+final class CellReferenceTests: XCTestCase {
+  private let decoder = XMLDecoder()
+
+  func testCellReference() {
+    do {
+      let c1 = try decoder.decode(Cell.self, from: exampleXML1)
+      XCTAssertEqual(c1,
+                     Cell(reference: CellReference(ColumnReference("A")!, 7),
+                          type: nil, s: nil, inlineString: nil, formula: nil,
+                          value: nil))
+      let c2 = try decoder.decode(Cell.self, from: exampleXML2)
+      XCTAssertEqual(c2,
+                     Cell(reference: CellReference(ColumnReference("ZA")!, 47),
+                     type: nil, s: nil, inlineString: nil, formula: nil,
+                     value: nil))
+
+    } catch {
+      XCTAssert(false, "unexpected error \(error)")
+    }
+  }
+
+  func testColumnReference() {
+    XCTAssertNil(ColumnReference(""))
+    XCTAssertNil(ColumnReference("934875"))
+    XCTAssertNil(ColumnReference("ø∫≈Ω"))
+    XCTAssertEqual(ColumnReference("A"), ColumnReference("A"))
+    XCTAssertNotEqual(ColumnReference("A"), ColumnReference("B"))
+
+    guard let a = ColumnReference("A"), let b = ColumnReference("B") else {
+      XCTAssert(false, "failed to create simple column references")
+      return
+    }
+
+    XCTAssertTrue(a < b)
+    XCTAssertFalse(b < a)
+    XCTAssertFalse(a > b)
+  }
+
+  static let allTests = [
+    ("testColumnReference", testColumnReference),
+    ("testCellReference", testCellReference),
+  ]
+}

--- a/Tests/CoreXLSXTests/CoreXLSXTests.swift
+++ b/Tests/CoreXLSXTests/CoreXLSXTests.swift
@@ -2,16 +2,69 @@ import XCTest
 @testable import CoreXLSX
 
 final class XLSXReaderTests: XCTestCase {
-  func testCategoriesFile() {
-    let currentWorkingPath = ProcessInfo.processInfo.environment["TESTS_PATH"]!
+  let currentWorkingPath = ProcessInfo.processInfo.environment["TESTS_PATH"]!
+  let sheetPath = "xl/worksheets/sheet1.xml"
 
+  func testColumnReference() {
+    XCTAssertNil(ColumnReference(""))
+    XCTAssertNil(ColumnReference("934875"))
+    XCTAssertNil(ColumnReference("ø∫≈Ω"))
+    XCTAssertEqual(ColumnReference("A"), ColumnReference("A"))
+    XCTAssertNotEqual(ColumnReference("A"), ColumnReference("B"))
+
+    guard let a = ColumnReference("A"), let b = ColumnReference("B") else {
+      XCTAssert(false, "failed to create simple column references")
+      return
+    }
+
+    XCTAssertTrue(a < b)
+    XCTAssertFalse(b < a)
+    XCTAssertFalse(a > b)
+  }
+
+  func testPublicAPI() {
+    do {
+      guard let file =
+        XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
+          XCTAssert(false, "failed to open the file")
+          return
+      }
+
+      XCTAssertEqual(try file.parseDocumentPaths(), ["xl/workbook.xml"])
+      XCTAssertEqual(try file.parseWorksheetPaths(), [sheetPath])
+
+      let ws = try file.parseWorksheet(at: sheetPath)
+      let allCells = ws.sheetData.rows
+        .map { $0.cells }
+        .reduce([], { $0 + $1 })
+      XCTAssertEqual(allCells.count, 90)
+
+      let rowReferences = ws.sheetData.rows.map { $0.reference }
+      let cellsFromRows = ws.cells(atRows: rowReferences)
+      XCTAssertEqual(allCells, cellsFromRows)
+
+      let cellsInFirstRow = ws.cells(atRows: [1])
+      XCTAssertEqual(cellsInFirstRow.count, 6)
+
+      let firstColumn = ("A" as UnicodeScalar).value
+      let lastColumn = ("F" as UnicodeScalar).value
+      let columnReferences = (firstColumn...lastColumn)
+        .compactMap { UnicodeScalar($0) }
+        .compactMap { ColumnReference(String($0)) }
+      let cellsFromAllColumns = ws.cells(atColumns: columnReferences)
+      XCTAssertEqual(allCells, cellsFromAllColumns)
+    } catch {
+      XCTAssert(false, "unexpected error \(error)")
+    }
+  }
+
+  func testLegacyPublicAPI() {
     do {
       guard let file =
       XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
         XCTAssert(false, "failed to open the file")
         return
       }
-      let sheetPath = "xl/worksheets/sheet1.xml"
 
       XCTAssertEqual(try file.parseDocumentPaths(), ["xl/workbook.xml"])
       XCTAssertEqual(try file.parseWorksheetPaths(), [sheetPath])
@@ -43,6 +96,8 @@ final class XLSXReaderTests: XCTestCase {
   }
 
   static var allTests = [
-    ("testCategoriesFile", testCategoriesFile),
+    ("testColumnReference", testColumnReference),
+    ("testPublicAPI", testPublicAPI),
+    ("testLegacyPublicAPI", testLegacyPublicAPI),
   ]
 }

--- a/Tests/CoreXLSXTests/CoreXLSXTests.swift
+++ b/Tests/CoreXLSXTests/CoreXLSXTests.swift
@@ -53,6 +53,15 @@ final class XLSXReaderTests: XCTestCase {
       XCTAssertEqual(try file.parseWorksheetPaths(), [sheetPath])
 
       let ws = try file.parseWorksheet(at: sheetPath)
+      XCTAssertEqual(ws.columns, ws.cols)
+      guard let mcs = ws.mergeCells else {
+        XCTAssert(false, "expected to parse merge cells from categories.xlsx")
+        return
+      }
+      for mc in mcs.items {
+        XCTAssertEqual(mc.reference, mc.ref)
+      }
+
       let allCells = ws.sheetData.rows
         .map { $0.cells }
         .reduce([], { $0 + $1 })

--- a/Tests/CoreXLSXTests/CoreXLSXTests.swift
+++ b/Tests/CoreXLSXTests/CoreXLSXTests.swift
@@ -95,7 +95,7 @@ final class XLSXReaderTests: XCTestCase {
     }
   }
 
-  static var allTests = [
+  static let allTests = [
     ("testColumnReference", testColumnReference),
     ("testPublicAPI", testPublicAPI),
     ("testLegacyPublicAPI", testLegacyPublicAPI),

--- a/Tests/CoreXLSXTests/CoreXLSXTests.swift
+++ b/Tests/CoreXLSXTests/CoreXLSXTests.swift
@@ -5,23 +5,6 @@ final class XLSXReaderTests: XCTestCase {
   let currentWorkingPath = ProcessInfo.processInfo.environment["TESTS_PATH"]!
   let sheetPath = "xl/worksheets/sheet1.xml"
 
-  func testColumnReference() {
-    XCTAssertNil(ColumnReference(""))
-    XCTAssertNil(ColumnReference("934875"))
-    XCTAssertNil(ColumnReference("ø∫≈Ω"))
-    XCTAssertEqual(ColumnReference("A"), ColumnReference("A"))
-    XCTAssertNotEqual(ColumnReference("A"), ColumnReference("B"))
-
-    guard let a = ColumnReference("A"), let b = ColumnReference("B") else {
-      XCTAssert(false, "failed to create simple column references")
-      return
-    }
-
-    XCTAssertTrue(a < b)
-    XCTAssertFalse(b < a)
-    XCTAssertFalse(a > b)
-  }
-
   func testPublicAPI() {
     do {
       guard let file =
@@ -96,7 +79,6 @@ final class XLSXReaderTests: XCTestCase {
   }
 
   static let allTests = [
-    ("testColumnReference", testColumnReference),
     ("testPublicAPI", testPublicAPI),
     ("testLegacyPublicAPI", testLegacyPublicAPI),
   ]

--- a/Tests/CoreXLSXTests/CoreXLSXTests.swift
+++ b/Tests/CoreXLSXTests/CoreXLSXTests.swift
@@ -75,7 +75,7 @@ final class XLSXReaderTests: XCTestCase {
         .reduce([], { $0 + $1 })
       XCTAssertEqual(allCells.count, 90)
 
-      let rowReferences = ws.sheetData.rows.map { $0.reference }
+      let rowReferences = ws.sheetData.rows.map { Int($0.reference) }
       let cellsFromRows = try file.cellsInWorksheet(at: sheetPath,
                                                     rows: rowReferences)
       XCTAssertEqual(allCells, cellsFromRows)

--- a/Tests/CoreXLSXTests/RelationshipsTests.swift
+++ b/Tests/CoreXLSXTests/RelationshipsTests.swift
@@ -1,0 +1,67 @@
+//
+//  RelationshipsTests.swift
+//  CoreXLSXTests
+//
+//  Created by Max Desiatov on 15/11/2018.
+//
+
+import XCTest
+import XMLCoder
+@testable import CoreXLSX
+
+private let exampleXML = """
+<Relationships
+xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship
+Id="rId1"
+Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties"
+Target="docProps/core.xml"/>
+
+<Relationship
+Id="rId2"
+Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties"
+Target="docProps/app.xml"/>
+
+<Relationship
+Id="rId3"
+Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+Target="xl/workbook.xml"/>
+
+</Relationships>
+""".data(using: .utf8)!
+
+private let parsed = [
+  Relationship(id: "rId1",
+               type: .coreProperties,
+               target: "docProps/core.xml"),
+  Relationship(id: "rId2",
+               type: .extendedProperties,
+               target: "docProps/app.xml"),
+  Relationship(id: "rId3",
+               type: .officeDocument,
+               target: "xl/workbook.xml"),
+]
+
+final class RelationshipsTests: XCTestCase {
+  private let decoder = XMLDecoder()
+
+  override func setUp() {
+    super.setUp()
+
+    decoder.keyDecodingStrategy = .convertFromCapitalized
+  }
+
+  func testRelationships() {
+    do {
+      let relationships = try decoder.decode(Relationships.self,
+                                             from: exampleXML)
+      XCTAssertEqual(relationships.items, parsed)
+    } catch {
+      XCTAssert(false, "unexpected error \(error)")
+    }
+  }
+
+  static let allTests = [
+    ("testRelationships", testRelationships),
+  ]
+}

--- a/Tests/CoreXLSXTests/XCTestManifests.swift
+++ b/Tests/CoreXLSXTests/XCTestManifests.swift
@@ -5,6 +5,7 @@ public func allTests() -> [XCTestCaseEntry] {
   return [
     testCase(CoreXLSXTests.allTests),
     testCase(RelationshipsTests.allTests),
+    testCase(CellReferenceTests.allTests),
   ]
 }
 #endif

--- a/Tests/CoreXLSXTests/XCTestManifests.swift
+++ b/Tests/CoreXLSXTests/XCTestManifests.swift
@@ -4,6 +4,7 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
   return [
     testCase(CoreXLSXTests.allTests),
+    testCase(RelationshipsTests.allTests),
   ]
 }
 #endif

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "Example"  # ignore folders and all its contents
+  - "Tests"


### PR DESCRIPTION
Previously cell references were stringly-typed allowing a user to create a cell reference with an arbitrary string. This is fixed with an introduction of new types: `CellReference` and `ColumnReference`. `ColumnReference` is a simple wrapper around `String` that guards against empty string and characters that can't be used as column references. Rows don't need a separate type for references as they map neatly to `UInt`, although API parts that used row references have changed to use `UInt` instead of `Int`. This is a breaking change that requires a major version bump.