### PR TITLE
Implement Strideable on ColumnReference

### DIFF
--- a/CoreXLSX.xcodeproj/xcshareddata/xcbaselines/CoreXLSX::CoreXLSXTests.xcbaseline/D6D73CD6-7630-483B-93EE-17F5BBBE89AF.plist
+++ b/CoreXLSX.xcodeproj/xcshareddata/xcbaselines/CoreXLSX::CoreXLSXTests.xcbaseline/D6D73CD6-7630-483B-93EE-17F5BBBE89AF.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>CellReferenceTests</key>
+		<dict>
+			<key>testColumnReferenceInitializerPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.00949</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testColumnReferenceIntInitializerPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.122</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testColumnReferenceStringInitializerPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0761</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/CoreXLSX.xcodeproj/xcshareddata/xcbaselines/CoreXLSX::CoreXLSXTests.xcbaseline/Info.plist
+++ b/CoreXLSX.xcodeproj/xcshareddata/xcbaselines/CoreXLSX::CoreXLSXTests.xcbaseline/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>D6D73CD6-7630-483B-93EE-17F5BBBE89AF</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>400</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i9</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2900</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>12</integer>
+				<key>modelCode</key>
+				<string>MacBookPro15,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>6</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Sources/CoreXLSX/ColumnReference.swift
+++ b/Sources/CoreXLSX/ColumnReference.swift
@@ -15,11 +15,17 @@ public struct ColumnReference {
   }
 
   public init?(_ value: Substring) {
-    guard !value.isEmpty, value.unicodeScalars.allSatisfy({
+    guard !value.isEmpty else {
+      return nil
+    }
+
+    let result = value.uppercased()
+
+    guard result.unicodeScalars.allSatisfy({
       ColumnReference.allowedCharacters.contains($0)
     }) else { return nil }
 
-    self.value = value.uppercased()
+    self.value = result
   }
 
   static let firstAllowedCharacter = "A" as UnicodeScalar
@@ -42,5 +48,15 @@ extension ColumnReference: Comparable {
 
   public static func == (lhs: ColumnReference, rhs: ColumnReference) -> Bool {
     return lhs.value == rhs.value
+  }
+}
+
+extension ColumnReference: Strideable {
+  public func distance(to: ColumnReference) -> Int {
+    return 0
+  }
+
+  public func advanced(by: Int) -> ColumnReference {
+    return self
   }
 }

--- a/Sources/CoreXLSX/ColumnReference.swift
+++ b/Sources/CoreXLSX/ColumnReference.swift
@@ -10,6 +10,44 @@ import Foundation
 public struct ColumnReference {
   public let value: String
 
+  let intValue: Int
+
+  init?(_ value: Int) {
+    guard value > 0 else { return nil }
+
+    intValue = value
+
+    // log(1) == 0, working around that
+    let symbolsCount = value == 1 ? 1 : Int(ceil(log(Double(value)) /
+      log(Double(ColumnReference.alphabetLength))))
+
+    var power = 1
+    var value = value
+    func symbolValue(i: Int) -> Int? {
+      let nextPower = power * ColumnReference.alphabetLength
+      let result = value % nextPower / power
+      power = nextPower
+      guard result == 0 else {
+        return result
+      }
+
+      value -= power
+      guard value >= 0 else {
+        return nil
+      }
+
+      return ColumnReference.alphabetLength
+    }
+
+    func reducer(acc: String, i: Int) -> String {
+      return String(Character(UnicodeScalar(ColumnReference.firstAllowedCharacter.value - 1 + UInt32(i))!)) + acc
+    }
+
+    let result = (0..<symbolsCount).compactMap(symbolValue).reduce("", reducer)
+
+    self.value = result
+  }
+
   public init?(_ value: String) {
     self.init(Substring(value))
   }
@@ -26,10 +64,35 @@ public struct ColumnReference {
     }) else { return nil }
 
     self.value = result
+
+    // store unicode scalars in array to allow indexing with integers
+    let scalars = Array(result.unicodeScalars)
+    let count = result.unicodeScalars.count
+
+    // pow(alphabetLength, $0) value where $0 is a given position,
+    // it can be quickly calculated by multiplying previous value of `power`
+    // from a previous iteration
+    var power = 1
+
+    self.intValue = (0..<count).map {
+      // integer value for a symbol at a given position
+      let symbolValue = Int(scalars[count - $0 - 1].value -
+        ColumnReference.firstAllowedCharacter.value + 1)
+
+      // total value calculated by multiplying symbolValue by the current
+      // position value (which is `power`)
+      let result = power * symbolValue
+      power *= ColumnReference.alphabetLength
+      return result
+    }
+    // sum all values
+    .reduce(0, +)
   }
 
   static let firstAllowedCharacter = "A" as UnicodeScalar
   static let lastAllowedCharacter = "Z" as UnicodeScalar
+  static let alphabetLength =
+    Int(lastAllowedCharacter.value - firstAllowedCharacter.value + 1)
 
   static let allowedCharacters =
     CharacterSet(charactersIn: firstAllowedCharacter...lastAllowedCharacter)
@@ -52,11 +115,13 @@ extension ColumnReference: Comparable {
 }
 
 extension ColumnReference: Strideable {
-  public func distance(to: ColumnReference) -> Int {
-    return 0
+  public func distance(to target: ColumnReference) -> Int {
+    return target.intValue - intValue
   }
 
-  public func advanced(by: Int) -> ColumnReference {
-    return self
+  public func advanced(by offset: Int) -> ColumnReference {
+    let targetIntValue = intValue + offset
+    guard targetIntValue > 0 else { return ColumnReference("A")! }
+    return ColumnReference(targetIntValue)!
   }
 }

--- a/Sources/CoreXLSX/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet.swift
@@ -36,7 +36,6 @@ public struct Worksheet: Codable {
   /// columns.
   public func cells<T>(atColumns: T) -> [Cell]
   where T: Collection, T.Element == ColumnReference {
-    print("atColumns.count is \(atColumns.count)")
     return sheetData.rows.map {
       return $0.cells.filter { atColumns.contains($0.reference.column) }
     }

--- a/Sources/CoreXLSX/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet.swift
@@ -34,19 +34,18 @@ public struct Worksheet: Codable {
 
   /// Return all cells that are contained in a given worksheet and set of
   /// columns.
-  public func cells(atColumns columns: [ColumnReference]) -> [Cell] {
+  public func cells<T>(atColumns: T) -> [Cell]
+  where T: Collection, T.Element == ColumnReference {
+    print("atColumns.count is \(atColumns.count)")
     return sheetData.rows.map {
-      let rowReference = $0.reference
-      let targetReferences = columns.map {
-        CellReference($0, rowReference)
-      }
-      return $0.cells.filter { targetReferences.contains($0.reference) }
+      return $0.cells.filter { atColumns.contains($0.reference.column) }
     }
     .reduce([]) { $0 + $1 }
   }
 
   /// Return all cells that are contained in a given worksheet and set of rows.
-  public func cells(atRows rows: [UInt]) -> [Cell] {
+  public func cells<T>(atRows rows: T) -> [Cell]
+  where T: Collection, T.Element == UInt {
     return sheetData.rows.filter { rows.contains($0.reference) }
       .reduce([]) { $0 + $1.cells }
   }

--- a/Tests/CoreXLSXTests/CellReferenceTests.swift
+++ b/Tests/CoreXLSXTests/CellReferenceTests.swift
@@ -75,22 +75,79 @@ final class CellReferenceTests: XCTestCase {
     XCTAssertFalse(a > b)
   }
 
-  func testColumnReferenceStrideable() {
+  func testColumnReferenceDistance() {
     guard let a = ColumnReference("A"), let z = ColumnReference("z"),
-    let az = ColumnReference("Az") else {
+    let aa = ColumnReference("AA"), let az = ColumnReference("Az"),
+    let ba = ColumnReference("ba"), let bz = ColumnReference("bz") else {
+      XCTAssert(false, "failed to create simple column references")
+      return
+    }
+    let alphabetLength = 26
+
+    XCTAssertEqual(a.intValue, 1)
+    XCTAssertEqual(z.intValue, alphabetLength)
+    XCTAssertEqual(aa.intValue, alphabetLength + 1)
+    XCTAssertEqual(az.intValue, alphabetLength * 2)
+    XCTAssertEqual(ba.intValue, alphabetLength * 2 + 1)
+    XCTAssertEqual((a...z).count, alphabetLength)
+    XCTAssertEqual((a...az).count, alphabetLength * 2)
+    XCTAssertEqual((a...ba).count, alphabetLength * 2 + 1)
+    XCTAssertEqual((az...ba).count, 2)
+    XCTAssertEqual((az...bz).count, alphabetLength + 1)
+  }
+
+  func testColumnReferenceIntInitializer() {
+    guard let a = ColumnReference("A"), let z = ColumnReference("z"),
+      let aa = ColumnReference("AA"), let az = ColumnReference("Az"),
+      let ba = ColumnReference("ba"), let bz = ColumnReference("bz"),
+      let abc = ColumnReference("abc"), let azz = ColumnReference("azz"),
+      let zz = ColumnReference("zz"), let azza = ColumnReference("azza") else {
+        XCTAssert(false, "failed to create simple column references")
+        return
+    }
+
+    XCTAssertEqual(ColumnReference(a.intValue), a)
+    XCTAssertEqual(ColumnReference(z.intValue), z)
+    XCTAssertEqual(ColumnReference(az.intValue), az)
+    XCTAssertEqual(ColumnReference(zz.intValue), zz)
+    XCTAssertEqual(ColumnReference(aa.intValue), aa)
+    XCTAssertEqual(ColumnReference(ba.intValue), ba)
+    XCTAssertEqual(ColumnReference(bz.intValue), bz)
+    XCTAssertEqual(ColumnReference(abc.intValue), abc)
+    XCTAssertEqual(ColumnReference(azz.intValue), azz)
+    XCTAssertEqual(ColumnReference(azza.intValue), azza)
+  }
+
+  func testColumnReferenceStringInitializerPerformance() {
+    measure {
+      for _ in 0..<10_000 {
+        _ = ColumnReference("kjhbjhblkjn")
+      }
+    }
+  }
+
+  func testColumnReferenceIntInitializerPerformance() {
+    measure {
+      for _ in 0..<10_000 {
+        _ = ColumnReference(Int.max / 10)
+      }
+    }
+  }
+
+  func testColumnReferenceAdvancedBy() {
+    guard let a = ColumnReference("A"), let bz = ColumnReference("bz") else {
       XCTAssert(false, "failed to create simple column references")
       return
     }
 
-    let alphabetLength = 26
-
-    XCTAssertEqual((a...z).count, alphabetLength)
-    XCTAssertEqual((a...az).count, alphabetLength * 2)
+    XCTAssertEqual((a...bz).reversed().reversed(), Array(a...bz))
   }
 
   static let allTests = [
     ("testColumnReference", testColumnReference),
     ("testCellReference", testCellReference),
-    ("testColumnReferenceStrideable", testColumnReferenceStrideable),
+    ("testColumnReferenceDistance", testColumnReferenceDistance),
+    ("testColumnReferenceStringInitializerPerformance",
+       testColumnReferenceStringInitializerPerformance)
   ]
 }

--- a/Tests/CoreXLSXTests/CellReferenceTests.swift
+++ b/Tests/CoreXLSXTests/CellReferenceTests.swift
@@ -75,8 +75,22 @@ final class CellReferenceTests: XCTestCase {
     XCTAssertFalse(a > b)
   }
 
+  func testColumnReferenceStrideable() {
+    guard let a = ColumnReference("A"), let z = ColumnReference("z"),
+    let az = ColumnReference("Az") else {
+      XCTAssert(false, "failed to create simple column references")
+      return
+    }
+
+    let alphabetLength = 26
+
+    XCTAssertEqual((a...z).count, alphabetLength)
+    XCTAssertEqual((a...az).count, alphabetLength * 2)
+  }
+
   static let allTests = [
     ("testColumnReference", testColumnReference),
     ("testCellReference", testCellReference),
+    ("testColumnReferenceStrideable", testColumnReferenceStrideable),
   ]
 }

--- a/Tests/CoreXLSXTests/CoreXLSXTests.swift
+++ b/Tests/CoreXLSXTests/CoreXLSXTests.swift
@@ -37,8 +37,8 @@ final class XLSXReaderTests: XCTestCase {
 
       XCTAssertEqual(allCells, ws.cells(atColumns: columnReferences))
 
-      let range = ColumnReference("A")!...ColumnReference("F")!
-      XCTAssertEqual(allCells, ws.cells(atColumns: range))
+      let closedRange = ColumnReference("A")!...ColumnReference("F")!
+      XCTAssertEqual(allCells, ws.cells(atColumns: closedRange))
     } catch {
       XCTAssert(false, "unexpected error \(error)")
     }

--- a/Tests/CoreXLSXTests/CoreXLSXTests.swift
+++ b/Tests/CoreXLSXTests/CoreXLSXTests.swift
@@ -34,8 +34,11 @@ final class XLSXReaderTests: XCTestCase {
       let columnReferences = (firstColumn...lastColumn)
         .compactMap { UnicodeScalar($0) }
         .compactMap { ColumnReference(String($0)) }
-      let cellsFromAllColumns = ws.cells(atColumns: columnReferences)
-      XCTAssertEqual(allCells, cellsFromAllColumns)
+
+      XCTAssertEqual(allCells, ws.cells(atColumns: columnReferences))
+
+      let range = ColumnReference("A")!...ColumnReference("F")!
+      XCTAssertEqual(allCells, ws.cells(atColumns: range))
     } catch {
       XCTAssert(false, "unexpected error \(error)")
     }


### PR DESCRIPTION
Currently `ColumnReference` lacks `Strideable` implementation, which does not allow closed ranges on column references like `ColumnReference("A")...ColumnReference("CZ")`. This prevents efficient filtering of cells with closed ranges requiring users to specify every column explicitly in arrays or whatever collection other than `ClosedRange`. Adding `Strideable` implementation with unit and performance tests here.