### PR TITLE
Add Carthage and support for tvOS and watchOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ Pods/
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
+Carthage/Checkouts
 
 Carthage/Build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
 # - pod install --project-directory=Example
 script:
 - pod lib lint
-- carthage version
 - carthage update
 - xcodebuild test -enableCodeCoverage YES -scheme CoreXLSX-Package
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ before_install:
 # - pod install --project-directory=Example
 script:
 - pod lib lint
-- swift package generate-xcodeproj --xcconfig-overrides Package.xcconfig
-- git checkout HEAD CoreXLSX.xcodeproj/xcshareddata/xcschemes/CoreXLSX-Package.xcscheme
+- carthage update
 - xcodebuild test -enableCodeCoverage YES -scheme CoreXLSX-Package
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 # - pod install --project-directory=Example
 script:
 - pod lib lint
+- carthage version
 - carthage update
 - xcodebuild test -enableCodeCoverage YES -scheme CoreXLSX-Package
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ before_install:
 script:
 - pod lib lint
 - carthage update
-- xcodebuild test -enableCodeCoverage YES -scheme CoreXLSX-Package
+- xcodebuild test -enableCodeCoverage YES -scheme CoreXLSXmacOS
+- xcodebuild -scheme CoreXLSXiOS
+- xcodebuild -scheme CoreXLSXwatchOS
+- xcodebuild -scheme CoreXLSXtvOS
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,2 @@
+github "weichsel/ZIPFoundation" ~> 0.9
+github "MaxDesiatov/XMLCoder" ~> 0.1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "weichsel/ZIPFoundation" ~> 0.9
-github "MaxDesiatov/XMLCoder" ~> 0.1.0
+github "MaxDesiatov/XMLCoder" ~> 0.2.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "MaxDesiatov/XMLCoder" "0.1.0"
+github "MaxDesiatov/XMLCoder" "0.2.1"
 github "weichsel/ZIPFoundation" "0.9.6"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,2 @@
+github "MaxDesiatov/XMLCoder" "0.1.0"
+github "weichsel/ZIPFoundation" "0.9.6"

--- a/CoreXLSX.podspec
+++ b/CoreXLSX.podspec
@@ -29,6 +29,7 @@ Excel spreadsheet (XLSX) format support in pure Swift.
   s.source           = { :git => 'https://github.com/MaxDesiatov/CoreXLSX.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/MaxDesiatov'
 
+  s.tvos.deployment_target = '9.0'
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'
 

--- a/CoreXLSX.podspec
+++ b/CoreXLSX.podspec
@@ -29,6 +29,7 @@ Excel spreadsheet (XLSX) format support in pure Swift.
   s.source           = { :git => 'https://github.com/MaxDesiatov/CoreXLSX.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/MaxDesiatov'
 
+  s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'

--- a/CoreXLSX.xcodeproj/CoreXLSXiOS_Info.plist
+++ b/CoreXLSX.xcodeproj/CoreXLSXiOS_Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/CoreXLSX.xcodeproj/CoreXLSXtvOS_Info.plist
+++ b/CoreXLSX.xcodeproj/CoreXLSXtvOS_Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -16,11 +16,7 @@
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
 </dict>
 </plist>

--- a/CoreXLSX.xcodeproj/CoreXLSXwatchOS_Info.plist
+++ b/CoreXLSX.xcodeproj/CoreXLSXwatchOS_Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/CoreXLSX.xcodeproj/project.pbxproj
+++ b/CoreXLSX.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -13,17 +13,22 @@
 		D15021C821A1C33E00BFA4FC /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D15021C421A1C31800BFA4FC /* XMLCoder.framework */; };
 		D15021CA21A1C3DF00BFA4FC /* XMLCoder.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D15021C421A1C31800BFA4FC /* XMLCoder.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D15021CB21A1C3DF00BFA4FC /* ZIPFoundation.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D15021C321A1C31800BFA4FC /* ZIPFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D15021DF21A1CB0500BFA4FC /* CellReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* CellReference.swift */; };
+		D15021E021A1CB0500BFA4FC /* ColumnReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* ColumnReference.swift */; };
+		D15021E121A1CB0500BFA4FC /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* CoreXLSX.swift */; };
+		D15021E221A1CB0500BFA4FC /* Relationships.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* Relationships.swift */; };
+		D15021E321A1CB0500BFA4FC /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Worksheet.swift */; };
+		D15021E621A1CB5000BFA4FC /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D15021E421A1CB5000BFA4FC /* ZIPFoundation.framework */; };
+		D15021E721A1CB5000BFA4FC /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D15021E521A1CB5000BFA4FC /* XMLCoder.framework */; };
 		OBJ_62 /* CellReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* CellReference.swift */; };
 		OBJ_63 /* ColumnReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* ColumnReference.swift */; };
 		OBJ_64 /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* CoreXLSX.swift */; };
 		OBJ_65 /* Relationships.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* Relationships.swift */; };
 		OBJ_66 /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Worksheet.swift */; };
-		OBJ_79 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_90 /* CellReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* CellReferenceTests.swift */; };
 		OBJ_91 /* CoreXLSXTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* CoreXLSXTests.swift */; };
 		OBJ_92 /* RelationshipsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* RelationshipsTests.swift */; };
 		OBJ_93 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* XCTestManifests.swift */; };
-		OBJ_95 /* CoreXLSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +60,16 @@
 		"CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = CoreXLSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D15021C321A1C31800BFA4FC /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/Mac/ZIPFoundation.framework; sourceTree = "<group>"; };
 		D15021C421A1C31800BFA4FC /* XMLCoder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XMLCoder.framework; path = Carthage/Build/Mac/XMLCoder.framework; sourceTree = "<group>"; };
+		D15021D121A1CA7D00BFA4FC /* CoreXLSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreXLSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D15021D421A1CA7D00BFA4FC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D15021D921A1CAB900BFA4FC /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		D15021DA21A1CAB900BFA4FC /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		D15021DB21A1CAB900BFA4FC /* CoreXLSX.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreXLSX.podspec; sourceTree = "<group>"; };
+		D15021DC21A1CABA00BFA4FC /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
+		D15021DD21A1CABA00BFA4FC /* codecov.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = codecov.yml; sourceTree = "<group>"; };
+		D15021DE21A1CABA00BFA4FC /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
+		D15021E421A1CB5000BFA4FC /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/tvOS/ZIPFoundation.framework; sourceTree = "<group>"; };
+		D15021E521A1CB5000BFA4FC /* XMLCoder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XMLCoder.framework; path = Carthage/Build/tvOS/XMLCoder.framework; sourceTree = "<group>"; };
 		OBJ_11 /* CellReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellReference.swift; sourceTree = "<group>"; };
 		OBJ_12 /* ColumnReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnReference.swift; sourceTree = "<group>"; };
 		OBJ_13 /* CoreXLSX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSX.swift; sourceTree = "<group>"; };
@@ -90,6 +105,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		D15021CE21A1CA7D00BFA4FC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D15021E621A1CB5000BFA4FC /* ZIPFoundation.framework in Frameworks */,
+				D15021E721A1CB5000BFA4FC /* XMLCoder.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		OBJ_67 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
@@ -105,7 +129,6 @@
 			files = (
 				D15021C721A1C33E00BFA4FC /* ZIPFoundation.framework in Frameworks */,
 				D15021C821A1C33E00BFA4FC /* XMLCoder.framework in Frameworks */,
-				OBJ_95 /* CoreXLSX.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -115,10 +138,36 @@
 		D15021C221A1C31800BFA4FC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D15021E921A1CB7700BFA4FC /* macOS */,
+				D15021E821A1CB6300BFA4FC /* tvOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		D15021D221A1CA7D00BFA4FC /* CoreXLSXtvOS */ = {
+			isa = PBXGroup;
+			children = (
+				D15021D421A1CA7D00BFA4FC /* Info.plist */,
+			);
+			path = CoreXLSXtvOS;
+			sourceTree = "<group>";
+		};
+		D15021E821A1CB6300BFA4FC /* tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				D15021E521A1CB5000BFA4FC /* XMLCoder.framework */,
+				D15021E421A1CB5000BFA4FC /* ZIPFoundation.framework */,
+			);
+			name = tvOS;
+			sourceTree = "<group>";
+		};
+		D15021E921A1CB7700BFA4FC /* macOS */ = {
+			isa = PBXGroup;
+			children = (
 				D15021C421A1C31800BFA4FC /* XMLCoder.framework */,
 				D15021C321A1C31800BFA4FC /* ZIPFoundation.framework */,
 			);
-			name = Frameworks;
+			name = macOS;
 			sourceTree = "<group>";
 		};
 		OBJ_10 /* CoreXLSX */ = {
@@ -232,25 +281,34 @@
 			path = Encoder;
 			sourceTree = "<group>";
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
+				D15021DE21A1CABA00BFA4FC /* Cartfile */,
+				D15021DA21A1CAB900BFA4FC /* CHANGELOG.md */,
+				D15021DD21A1CABA00BFA4FC /* codecov.yml */,
+				D15021DB21A1CAB900BFA4FC /* CoreXLSX.podspec */,
+				D15021DC21A1CABA00BFA4FC /* LICENSE.md */,
+				D15021D921A1CAB900BFA4FC /* README.md */,
 				OBJ_6 /* Package.swift */,
 				OBJ_7 /* Configs */,
 				OBJ_9 /* Sources */,
 				OBJ_16 /* Tests */,
 				OBJ_24 /* Dependencies */,
+				D15021D221A1CA7D00BFA4FC /* CoreXLSXtvOS */,
 				OBJ_52 /* Products */,
 				D15021C221A1C31800BFA4FC /* Frameworks */,
 			);
-			name = "";
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		OBJ_52 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				"CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */,
 				"CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */,
+				D15021D121A1CA7D00BFA4FC /* CoreXLSX.framework */,
 			);
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
@@ -273,10 +331,20 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		D15021CC21A1CA7D00BFA4FC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
-		"CoreXLSX::CoreXLSX" /* CoreXLSX */ = {
+		"CoreXLSX::CoreXLSX" /* CoreXLSXmacOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_58 /* Build configuration list for PBXNativeTarget "CoreXLSX" */;
+			buildConfigurationList = OBJ_58 /* Build configuration list for PBXNativeTarget "CoreXLSXmacOS" */;
 			buildPhases = (
 				OBJ_61 /* Sources */,
 				OBJ_67 /* Frameworks */,
@@ -285,7 +353,7 @@
 			);
 			dependencies = (
 			);
-			name = CoreXLSX;
+			name = CoreXLSXmacOS;
 			productName = CoreXLSX;
 			productReference = "CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */;
 			productType = "com.apple.product-type.framework";
@@ -308,18 +376,22 @@
 			productReference = "CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		"CoreXLSX::SwiftPMPackageDescription" /* CoreXLSXPackageDescription */ = {
+		D15021D021A1CA7D00BFA4FC /* CoreXLSXtvOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_75 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */;
+			buildConfigurationList = D15021D621A1CA7D00BFA4FC /* Build configuration list for PBXNativeTarget "CoreXLSXtvOS" */;
 			buildPhases = (
-				OBJ_78 /* Sources */,
+				D15021CC21A1CA7D00BFA4FC /* Headers */,
+				D15021CD21A1CA7D00BFA4FC /* Sources */,
+				D15021CE21A1CA7D00BFA4FC /* Frameworks */,
+				D15021CF21A1CA7D00BFA4FC /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = CoreXLSXPackageDescription;
-			productName = CoreXLSXPackageDescription;
+			name = CoreXLSXtvOS;
+			productName = CoreXLSXtvOS;
+			productReference = D15021D121A1CA7D00BFA4FC /* CoreXLSX.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -329,27 +401,54 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 9999;
+				TargetAttributes = {
+					D15021D021A1CA7D00BFA4FC = {
+						CreatedOnToolsVersion = 10.1;
+					};
+				};
 			};
 			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "CoreXLSX" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 10.0";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_52 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				"CoreXLSX::CoreXLSX" /* CoreXLSX */,
-				"CoreXLSX::SwiftPMPackageDescription" /* CoreXLSXPackageDescription */,
+				"CoreXLSX::CoreXLSX" /* CoreXLSXmacOS */,
 				"CoreXLSX::CoreXLSXTests" /* CoreXLSXTests */,
+				D15021D021A1CA7D00BFA4FC /* CoreXLSXtvOS */,
 			);
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		D15021CF21A1CA7D00BFA4FC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
+		D15021CD21A1CA7D00BFA4FC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D15021E121A1CB0500BFA4FC /* CoreXLSX.swift in Sources */,
+				D15021DF21A1CB0500BFA4FC /* CellReference.swift in Sources */,
+				D15021E021A1CB0500BFA4FC /* ColumnReference.swift in Sources */,
+				D15021E221A1CB0500BFA4FC /* Relationships.swift in Sources */,
+				D15021E321A1CB0500BFA4FC /* Worksheet.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		OBJ_61 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
@@ -359,14 +458,6 @@
 				OBJ_64 /* CoreXLSX.swift in Sources */,
 				OBJ_65 /* Relationships.swift in Sources */,
 				OBJ_66 /* Worksheet.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_78 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_79 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -386,12 +477,164 @@
 /* Begin PBXTargetDependency section */
 		OBJ_98 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "CoreXLSX::CoreXLSX" /* CoreXLSX */;
+			target = "CoreXLSX::CoreXLSX" /* CoreXLSXmacOS */;
 			targetProxy = D15021BE21A1C23700BFA4FC /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		D15021D721A1CA7D00BFA4FC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXtvOS_Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.CoreXLSX.CoreXLSXtvOS;
+				PRODUCT_MODULE_NAME = CoreXLSX;
+				PRODUCT_NAME = CoreXLSX;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		D15021D821A1CA7D00BFA4FC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXtvOS_Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.CoreXLSX.CoreXLSXtvOS;
+				PRODUCT_MODULE_NAME = CoreXLSX;
+				PRODUCT_NAME = CoreXLSX;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		OBJ_3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -433,7 +676,8 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				USE_HEADERMAP = NO;
 			};
 			name = Release;
@@ -450,11 +694,14 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSX_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+				);
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = CoreXLSX;
+				PRODUCT_BUNDLE_IDENTIFIER = com.CoreXLSX.CoreXLSXmacOS;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -476,35 +723,20 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSX_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+				);
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = CoreXLSX;
+				PRODUCT_BUNDLE_IDENTIFIER = com.CoreXLSX.CoreXLSXmacOS;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 4.2;
 				TARGET_NAME = CoreXLSX;
-			};
-			name = Release;
-		};
-		OBJ_76 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.2;
-			};
-			name = Debug;
-		};
-		OBJ_77 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -521,7 +753,11 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -544,7 +780,11 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -557,6 +797,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		D15021D621A1CA7D00BFA4FC /* Build configuration list for PBXNativeTarget "CoreXLSXtvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D15021D721A1CA7D00BFA4FC /* Debug */,
+				D15021D821A1CA7D00BFA4FC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		OBJ_2 /* Build configuration list for PBXProject "CoreXLSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -566,20 +815,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_58 /* Build configuration list for PBXNativeTarget "CoreXLSX" */ = {
+		OBJ_58 /* Build configuration list for PBXNativeTarget "CoreXLSXmacOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				OBJ_59 /* Debug */,
 				OBJ_60 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_75 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_76 /* Debug */,
-				OBJ_77 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/CoreXLSX.xcodeproj/project.pbxproj
+++ b/CoreXLSX.xcodeproj/project.pbxproj
@@ -20,6 +20,20 @@
 		D15021E321A1CB0500BFA4FC /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Worksheet.swift */; };
 		D15021E621A1CB5000BFA4FC /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D15021E421A1CB5000BFA4FC /* ZIPFoundation.framework */; };
 		D15021E721A1CB5000BFA4FC /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D15021E521A1CB5000BFA4FC /* XMLCoder.framework */; };
+		D15021F921A1D1A500BFA4FC /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D15021F721A1D1A500BFA4FC /* XMLCoder.framework */; };
+		D15021FA21A1D1A500BFA4FC /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D15021F821A1D1A500BFA4FC /* ZIPFoundation.framework */; };
+		D15021FB21A1D1DB00BFA4FC /* CellReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* CellReference.swift */; };
+		D15021FC21A1D1DB00BFA4FC /* ColumnReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* ColumnReference.swift */; };
+		D15021FD21A1D1DB00BFA4FC /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* CoreXLSX.swift */; };
+		D15021FE21A1D1DB00BFA4FC /* Relationships.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* Relationships.swift */; };
+		D15021FF21A1D1DB00BFA4FC /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Worksheet.swift */; };
+		D150220F21A1D95400BFA4FC /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D150220D21A1D95400BFA4FC /* XMLCoder.framework */; };
+		D150221021A1D95400BFA4FC /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D150220E21A1D95400BFA4FC /* ZIPFoundation.framework */; };
+		D150221121A1D97E00BFA4FC /* CellReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* CellReference.swift */; };
+		D150221221A1D97E00BFA4FC /* ColumnReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* ColumnReference.swift */; };
+		D150221321A1D97E00BFA4FC /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* CoreXLSX.swift */; };
+		D150221421A1D97E00BFA4FC /* Relationships.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* Relationships.swift */; };
+		D150221521A1D97E00BFA4FC /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Worksheet.swift */; };
 		OBJ_62 /* CellReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* CellReference.swift */; };
 		OBJ_63 /* ColumnReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* ColumnReference.swift */; };
 		OBJ_64 /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* CoreXLSX.swift */; };
@@ -61,7 +75,6 @@
 		D15021C321A1C31800BFA4FC /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/Mac/ZIPFoundation.framework; sourceTree = "<group>"; };
 		D15021C421A1C31800BFA4FC /* XMLCoder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XMLCoder.framework; path = Carthage/Build/Mac/XMLCoder.framework; sourceTree = "<group>"; };
 		D15021D121A1CA7D00BFA4FC /* CoreXLSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreXLSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D15021D421A1CA7D00BFA4FC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D15021D921A1CAB900BFA4FC /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		D15021DA21A1CAB900BFA4FC /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		D15021DB21A1CAB900BFA4FC /* CoreXLSX.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreXLSX.podspec; sourceTree = "<group>"; };
@@ -70,6 +83,12 @@
 		D15021DE21A1CABA00BFA4FC /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		D15021E421A1CB5000BFA4FC /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/tvOS/ZIPFoundation.framework; sourceTree = "<group>"; };
 		D15021E521A1CB5000BFA4FC /* XMLCoder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XMLCoder.framework; path = Carthage/Build/tvOS/XMLCoder.framework; sourceTree = "<group>"; };
+		D15021EF21A1D11900BFA4FC /* CoreXLSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreXLSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D15021F721A1D1A500BFA4FC /* XMLCoder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XMLCoder.framework; path = Carthage/Build/iOS/XMLCoder.framework; sourceTree = "<group>"; };
+		D15021F821A1D1A500BFA4FC /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/iOS/ZIPFoundation.framework; sourceTree = "<group>"; };
+		D150220521A1D8DC00BFA4FC /* CoreXLSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreXLSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D150220D21A1D95400BFA4FC /* XMLCoder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XMLCoder.framework; path = Carthage/Build/watchOS/XMLCoder.framework; sourceTree = "<group>"; };
+		D150220E21A1D95400BFA4FC /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/watchOS/ZIPFoundation.framework; sourceTree = "<group>"; };
 		OBJ_11 /* CellReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellReference.swift; sourceTree = "<group>"; };
 		OBJ_12 /* ColumnReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnReference.swift; sourceTree = "<group>"; };
 		OBJ_13 /* CoreXLSX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSX.swift; sourceTree = "<group>"; };
@@ -114,6 +133,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D15021EC21A1D11900BFA4FC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D15021F921A1D1A500BFA4FC /* XMLCoder.framework in Frameworks */,
+				D15021FA21A1D1A500BFA4FC /* ZIPFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D150220221A1D8DC00BFA4FC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D150220F21A1D95400BFA4FC /* XMLCoder.framework in Frameworks */,
+				D150221021A1D95400BFA4FC /* ZIPFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		OBJ_67 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
@@ -138,18 +175,14 @@
 		D15021C221A1C31800BFA4FC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D15021F721A1D1A500BFA4FC /* XMLCoder.framework */,
+				D15021F821A1D1A500BFA4FC /* ZIPFoundation.framework */,
+				D150220D21A1D95400BFA4FC /* XMLCoder.framework */,
+				D150220E21A1D95400BFA4FC /* ZIPFoundation.framework */,
 				D15021E921A1CB7700BFA4FC /* macOS */,
 				D15021E821A1CB6300BFA4FC /* tvOS */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		D15021D221A1CA7D00BFA4FC /* CoreXLSXtvOS */ = {
-			isa = PBXGroup;
-			children = (
-				D15021D421A1CA7D00BFA4FC /* Info.plist */,
-			);
-			path = CoreXLSXtvOS;
 			sourceTree = "<group>";
 		};
 		D15021E821A1CB6300BFA4FC /* tvOS */ = {
@@ -295,7 +328,6 @@
 				OBJ_9 /* Sources */,
 				OBJ_16 /* Tests */,
 				OBJ_24 /* Dependencies */,
-				D15021D221A1CA7D00BFA4FC /* CoreXLSXtvOS */,
 				OBJ_52 /* Products */,
 				D15021C221A1C31800BFA4FC /* Frameworks */,
 			);
@@ -309,6 +341,8 @@
 				"CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */,
 				"CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */,
 				D15021D121A1CA7D00BFA4FC /* CoreXLSX.framework */,
+				D15021EF21A1D11900BFA4FC /* CoreXLSX.framework */,
+				D150220521A1D8DC00BFA4FC /* CoreXLSX.framework */,
 			);
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
@@ -333,6 +367,20 @@
 
 /* Begin PBXHeadersBuildPhase section */
 		D15021CC21A1CA7D00BFA4FC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D15021EA21A1D11900BFA4FC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D150220021A1D8DC00BFA4FC /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -394,6 +442,42 @@
 			productReference = D15021D121A1CA7D00BFA4FC /* CoreXLSX.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		D15021EE21A1D11900BFA4FC /* CoreXLSXiOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D15021F621A1D11A00BFA4FC /* Build configuration list for PBXNativeTarget "CoreXLSXiOS" */;
+			buildPhases = (
+				D15021EA21A1D11900BFA4FC /* Headers */,
+				D15021EB21A1D11900BFA4FC /* Sources */,
+				D15021EC21A1D11900BFA4FC /* Frameworks */,
+				D15021ED21A1D11900BFA4FC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CoreXLSXiOS;
+			productName = CoreXLSXiOS;
+			productReference = D15021EF21A1D11900BFA4FC /* CoreXLSX.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D150220421A1D8DC00BFA4FC /* CoreXLSXwatchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D150220A21A1D8DC00BFA4FC /* Build configuration list for PBXNativeTarget "CoreXLSXwatchOS" */;
+			buildPhases = (
+				D150220021A1D8DC00BFA4FC /* Headers */,
+				D150220121A1D8DC00BFA4FC /* Sources */,
+				D150220221A1D8DC00BFA4FC /* Frameworks */,
+				D150220321A1D8DC00BFA4FC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CoreXLSXwatchOS;
+			productName = CoreXLSXwatchOS;
+			productReference = D150220521A1D8DC00BFA4FC /* CoreXLSX.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -403,6 +487,12 @@
 				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					D15021D021A1CA7D00BFA4FC = {
+						CreatedOnToolsVersion = 10.1;
+					};
+					D15021EE21A1D11900BFA4FC = {
+						CreatedOnToolsVersion = 10.1;
+					};
+					D150220421A1D8DC00BFA4FC = {
 						CreatedOnToolsVersion = 10.1;
 					};
 				};
@@ -422,12 +512,28 @@
 				"CoreXLSX::CoreXLSX" /* CoreXLSXmacOS */,
 				"CoreXLSX::CoreXLSXTests" /* CoreXLSXTests */,
 				D15021D021A1CA7D00BFA4FC /* CoreXLSXtvOS */,
+				D15021EE21A1D11900BFA4FC /* CoreXLSXiOS */,
+				D150220421A1D8DC00BFA4FC /* CoreXLSXwatchOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		D15021CF21A1CA7D00BFA4FC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D15021ED21A1D11900BFA4FC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D150220321A1D8DC00BFA4FC /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -446,6 +552,30 @@
 				D15021E021A1CB0500BFA4FC /* ColumnReference.swift in Sources */,
 				D15021E221A1CB0500BFA4FC /* Relationships.swift in Sources */,
 				D15021E321A1CB0500BFA4FC /* Worksheet.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D15021EB21A1D11900BFA4FC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D15021FD21A1D1DB00BFA4FC /* CoreXLSX.swift in Sources */,
+				D15021FB21A1D1DB00BFA4FC /* CellReference.swift in Sources */,
+				D15021FC21A1D1DB00BFA4FC /* ColumnReference.swift in Sources */,
+				D15021FE21A1D1DB00BFA4FC /* Relationships.swift in Sources */,
+				D15021FF21A1D1DB00BFA4FC /* Worksheet.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D150220121A1D8DC00BFA4FC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D150221321A1D97E00BFA4FC /* CoreXLSX.swift in Sources */,
+				D150221121A1D97E00BFA4FC /* CellReference.swift in Sources */,
+				D150221221A1D97E00BFA4FC /* ColumnReference.swift in Sources */,
+				D150221421A1D97E00BFA4FC /* Relationships.swift in Sources */,
+				D150221521A1D97E00BFA4FC /* Worksheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -546,10 +676,10 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.CoreXLSX.CoreXLSXtvOS;
-				PRODUCT_MODULE_NAME = CoreXLSX;
 				PRODUCT_NAME = CoreXLSX;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
@@ -622,16 +752,322 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.CoreXLSX.CoreXLSXtvOS;
-				PRODUCT_MODULE_NAME = CoreXLSX;
 				PRODUCT_NAME = CoreXLSX;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		D15021F421A1D11A00BFA4FC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXiOS_Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.CoreXLSX.CoreXLSXiOS;
+				PRODUCT_NAME = CoreXLSX;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		D15021F521A1D11A00BFA4FC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXiOS_Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.CoreXLSX.CoreXLSXiOS;
+				PRODUCT_NAME = CoreXLSX;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		D150220B21A1D8DC00BFA4FC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXwatchOS_Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.CoreXLSX.CoreXLSXwatchOS;
+				PRODUCT_NAME = CoreXLSX;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		D150220C21A1D8DC00BFA4FC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXwatchOS_Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.CoreXLSX.CoreXLSXwatchOS;
+				PRODUCT_NAME = CoreXLSX;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = 4;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -702,9 +1138,9 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.CoreXLSX.CoreXLSXmacOS;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 4.2;
 				TARGET_NAME = CoreXLSX;
@@ -731,9 +1167,9 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.CoreXLSX.CoreXLSXmacOS;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 4.2;
 				TARGET_NAME = CoreXLSX;
@@ -802,6 +1238,24 @@
 			buildConfigurations = (
 				D15021D721A1CA7D00BFA4FC /* Debug */,
 				D15021D821A1CA7D00BFA4FC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D15021F621A1D11A00BFA4FC /* Build configuration list for PBXNativeTarget "CoreXLSXiOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D15021F421A1D11A00BFA4FC /* Debug */,
+				D15021F521A1D11A00BFA4FC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D150220A21A1D8DC00BFA4FC /* Build configuration list for PBXNativeTarget "CoreXLSXwatchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D150220B21A1D8DC00BFA4FC /* Debug */,
+				D150220C21A1D8DC00BFA4FC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/CoreXLSX.xcodeproj/project.pbxproj
+++ b/CoreXLSX.xcodeproj/project.pbxproj
@@ -6,323 +6,254 @@
 	objectVersion = 46;
 	objects = {
 
-/* Begin PBXAggregateTarget section */
-		"CoreXLSX::CoreXLSXPackageTests::ProductTarget" /* CoreXLSXPackageTests */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = OBJ_74 /* Build configuration list for PBXAggregateTarget "CoreXLSXPackageTests" */;
-			buildPhases = (
-			);
-			dependencies = (
-				OBJ_77 /* PBXTargetDependency */,
-			);
-			name = CoreXLSXPackageTests;
-			productName = CoreXLSXPackageTests;
-		};
-/* End PBXAggregateTarget section */
-
 /* Begin PBXBuildFile section */
-		D123DC9D219B471D007F6E04 /* ColumnReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D123DC9C219B471D007F6E04 /* ColumnReference.swift */; };
-		D123DC9F219C29DD007F6E04 /* CellReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D123DC9E219C29DD007F6E04 /* CellReference.swift */; };
-		D15E8358219D7F0F00EB4544 /* RelationshipsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15E8357219D7F0F00EB4544 /* RelationshipsTests.swift */; };
-		D15E835A219D87B100EB4544 /* CellReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15E8359219D87B100EB4544 /* CellReferenceTests.swift */; };
-		OBJ_100 /* XMLUnkeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* XMLUnkeyedDecodingContainer.swift */; };
-		OBJ_101 /* EncodingErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* EncodingErrorExtension.swift */; };
-		OBJ_102 /* XMLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* XMLEncoder.swift */; };
-		OBJ_103 /* XMLEncodingStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* XMLEncodingStorage.swift */; };
-		OBJ_104 /* XMLReferencingEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* XMLReferencingEncoder.swift */; };
-		OBJ_105 /* ISO8601DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* ISO8601DateFormatter.swift */; };
-		OBJ_106 /* XMLKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* XMLKey.swift */; };
-		OBJ_107 /* XMLStackParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_45 /* XMLStackParser.swift */; };
-		OBJ_114 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_46 /* Package.swift */; };
-		OBJ_119 /* Archive+Reading.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* Archive+Reading.swift */; };
-		OBJ_120 /* Archive+Writing.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* Archive+Writing.swift */; };
-		OBJ_121 /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* Archive.swift */; };
-		OBJ_122 /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* Data+Compression.swift */; };
-		OBJ_123 /* Data+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* Data+Serialization.swift */; };
-		OBJ_124 /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* Entry.swift */; };
-		OBJ_125 /* FileManager+ZIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* FileManager+ZIP.swift */; };
-		OBJ_132 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* Package.swift */; };
-		OBJ_57 /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* CoreXLSX.swift */; };
-		OBJ_58 /* Relationships.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* Relationships.swift */; };
-		OBJ_59 /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* Worksheet.swift */; };
-		OBJ_61 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */; };
-		OBJ_62 /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XMLCoder::XMLCoder::Product" /* XMLCoder.framework */; };
-		OBJ_72 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
-		OBJ_83 /* CoreXLSXTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* CoreXLSXTests.swift */; };
-		OBJ_84 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* XCTestManifests.swift */; };
-		OBJ_86 /* CoreXLSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */; };
-		OBJ_87 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */; };
-		OBJ_88 /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XMLCoder::XMLCoder::Product" /* XMLCoder.framework */; };
-		OBJ_96 /* DecodingErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* DecodingErrorExtension.swift */; };
-		OBJ_97 /* XMLDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* XMLDecoder.swift */; };
-		OBJ_98 /* XMLDecodingStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* XMLDecodingStorage.swift */; };
-		OBJ_99 /* XMLKeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_36 /* XMLKeyedDecodingContainer.swift */; };
+		D15021C521A1C31800BFA4FC /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D15021C321A1C31800BFA4FC /* ZIPFoundation.framework */; };
+		D15021C621A1C31800BFA4FC /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D15021C421A1C31800BFA4FC /* XMLCoder.framework */; };
+		D15021C721A1C33E00BFA4FC /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D15021C321A1C31800BFA4FC /* ZIPFoundation.framework */; };
+		D15021C821A1C33E00BFA4FC /* XMLCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D15021C421A1C31800BFA4FC /* XMLCoder.framework */; };
+		D15021CA21A1C3DF00BFA4FC /* XMLCoder.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D15021C421A1C31800BFA4FC /* XMLCoder.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D15021CB21A1C3DF00BFA4FC /* ZIPFoundation.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D15021C321A1C31800BFA4FC /* ZIPFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		OBJ_62 /* CellReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* CellReference.swift */; };
+		OBJ_63 /* ColumnReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* ColumnReference.swift */; };
+		OBJ_64 /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* CoreXLSX.swift */; };
+		OBJ_65 /* Relationships.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* Relationships.swift */; };
+		OBJ_66 /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Worksheet.swift */; };
+		OBJ_79 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_90 /* CellReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* CellReferenceTests.swift */; };
+		OBJ_91 /* CoreXLSXTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* CoreXLSXTests.swift */; };
+		OBJ_92 /* RelationshipsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* RelationshipsTests.swift */; };
+		OBJ_93 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* XCTestManifests.swift */; };
+		OBJ_95 /* CoreXLSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		D155EAEF219ADA9E00D4F47E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "ZIPFoundation::ZIPFoundation";
-			remoteInfo = ZIPFoundation;
-		};
-		D155EAF0219ADA9E00D4F47E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "XMLCoder::XMLCoder";
-			remoteInfo = XMLCoder;
-		};
-		D155EAF1219ADA9E00D4F47E /* PBXContainerItemProxy */ = {
+		D15021BE21A1C23700BFA4FC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "CoreXLSX::CoreXLSX";
 			remoteInfo = CoreXLSX;
 		};
-		D155EAF2219ADA9E00D4F47E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "ZIPFoundation::ZIPFoundation";
-			remoteInfo = ZIPFoundation;
-		};
-		D155EAF3219ADA9E00D4F47E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "XMLCoder::XMLCoder";
-			remoteInfo = XMLCoder;
-		};
-		D155EAF4219ADA9E00D4F47E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "CoreXLSX::CoreXLSXTests";
-			remoteInfo = CoreXLSXTests;
-		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		D15021C921A1C3BB00BFA4FC /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				D15021CA21A1C3DF00BFA4FC /* XMLCoder.framework in CopyFiles */,
+				D15021CB21A1C3DF00BFA4FC /* ZIPFoundation.framework in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
-		"CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CoreXLSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = CoreXLSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D123DC9C219B471D007F6E04 /* ColumnReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnReference.swift; sourceTree = "<group>"; };
-		D123DC9E219C29DD007F6E04 /* CellReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellReference.swift; sourceTree = "<group>"; };
-		D123DCA0219C35BA007F6E04 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
-		D155EAF5219ADF9C00D4F47E /* CoreXLSX.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreXLSX.podspec; sourceTree = "<group>"; };
-		D155EAF6219ADF9C00D4F47E /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		D15E8357219D7F0F00EB4544 /* RelationshipsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipsTests.swift; sourceTree = "<group>"; };
-		D15E8359219D87B100EB4544 /* CellReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellReferenceTests.swift; sourceTree = "<group>"; };
-		OBJ_11 /* CoreXLSX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSX.swift; sourceTree = "<group>"; };
-		OBJ_12 /* Relationships.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Relationships.swift; sourceTree = "<group>"; };
-		OBJ_13 /* Worksheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Worksheet.swift; sourceTree = "<group>"; };
-		OBJ_16 /* CoreXLSXTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSXTests.swift; sourceTree = "<group>"; };
-		OBJ_17 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
-		OBJ_18 /* Example */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Example; sourceTree = SOURCE_ROOT; };
-		OBJ_22 /* Archive+Reading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Reading.swift"; sourceTree = "<group>"; };
-		OBJ_23 /* Archive+Writing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Writing.swift"; sourceTree = "<group>"; };
-		OBJ_24 /* Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Archive.swift; sourceTree = "<group>"; };
-		OBJ_25 /* Data+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Compression.swift"; sourceTree = "<group>"; };
-		OBJ_26 /* Data+Serialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Serialization.swift"; sourceTree = "<group>"; };
-		OBJ_27 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
-		OBJ_28 /* FileManager+ZIP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+ZIP.swift"; sourceTree = "<group>"; };
-		OBJ_29 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/maxd/Documents/CoreXLSX/.build/checkouts/ZIPFoundation.git-1553630773966528904/Package.swift"; sourceTree = "<group>"; };
-		OBJ_33 /* DecodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingErrorExtension.swift; sourceTree = "<group>"; };
-		OBJ_34 /* XMLDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLDecoder.swift; sourceTree = "<group>"; };
-		OBJ_35 /* XMLDecodingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLDecodingStorage.swift; sourceTree = "<group>"; };
-		OBJ_36 /* XMLKeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLKeyedDecodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_37 /* XMLUnkeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLUnkeyedDecodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_39 /* EncodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingErrorExtension.swift; sourceTree = "<group>"; };
-		OBJ_40 /* XMLEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLEncoder.swift; sourceTree = "<group>"; };
-		OBJ_41 /* XMLEncodingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLEncodingStorage.swift; sourceTree = "<group>"; };
-		OBJ_42 /* XMLReferencingEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLReferencingEncoder.swift; sourceTree = "<group>"; };
-		OBJ_43 /* ISO8601DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISO8601DateFormatter.swift; sourceTree = "<group>"; };
-		OBJ_44 /* XMLKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLKey.swift; sourceTree = "<group>"; };
-		OBJ_45 /* XMLStackParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLStackParser.swift; sourceTree = "<group>"; };
-		OBJ_46 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/maxd/Documents/CoreXLSX/.build/checkouts/XMLCoder.git--8189013463900790701/Package.swift"; sourceTree = "<group>"; };
+		"CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CoreXLSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = CoreXLSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D15021C321A1C31800BFA4FC /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/Mac/ZIPFoundation.framework; sourceTree = "<group>"; };
+		D15021C421A1C31800BFA4FC /* XMLCoder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XMLCoder.framework; path = Carthage/Build/Mac/XMLCoder.framework; sourceTree = "<group>"; };
+		OBJ_11 /* CellReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellReference.swift; sourceTree = "<group>"; };
+		OBJ_12 /* ColumnReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnReference.swift; sourceTree = "<group>"; };
+		OBJ_13 /* CoreXLSX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSX.swift; sourceTree = "<group>"; };
+		OBJ_14 /* Relationships.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Relationships.swift; sourceTree = "<group>"; };
+		OBJ_15 /* Worksheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Worksheet.swift; sourceTree = "<group>"; };
+		OBJ_18 /* CellReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellReferenceTests.swift; sourceTree = "<group>"; };
+		OBJ_19 /* CoreXLSXTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSXTests.swift; sourceTree = "<group>"; };
+		OBJ_20 /* RelationshipsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipsTests.swift; sourceTree = "<group>"; };
+		OBJ_21 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
+		OBJ_27 /* Archive+Reading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Reading.swift"; sourceTree = "<group>"; };
+		OBJ_28 /* Archive+Writing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Writing.swift"; sourceTree = "<group>"; };
+		OBJ_29 /* Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Archive.swift; sourceTree = "<group>"; };
+		OBJ_30 /* Data+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Compression.swift"; sourceTree = "<group>"; };
+		OBJ_31 /* Data+Serialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Serialization.swift"; sourceTree = "<group>"; };
+		OBJ_32 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
+		OBJ_33 /* FileManager+ZIP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+ZIP.swift"; sourceTree = "<group>"; };
+		OBJ_34 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/maxd/Documents/CoreXLSX/.build/checkouts/ZIPFoundation.git-1553630773966528904/Package.swift"; sourceTree = "<group>"; };
+		OBJ_38 /* DecodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingErrorExtension.swift; sourceTree = "<group>"; };
+		OBJ_39 /* XMLDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLDecoder.swift; sourceTree = "<group>"; };
+		OBJ_40 /* XMLDecodingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLDecodingStorage.swift; sourceTree = "<group>"; };
+		OBJ_41 /* XMLKeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLKeyedDecodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_42 /* XMLUnkeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLUnkeyedDecodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_44 /* EncodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingErrorExtension.swift; sourceTree = "<group>"; };
+		OBJ_45 /* XMLEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLEncoder.swift; sourceTree = "<group>"; };
+		OBJ_46 /* XMLEncodingStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLEncodingStorage.swift; sourceTree = "<group>"; };
+		OBJ_47 /* XMLReferencingEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLReferencingEncoder.swift; sourceTree = "<group>"; };
+		OBJ_48 /* ISO8601DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISO8601DateFormatter.swift; sourceTree = "<group>"; };
+		OBJ_49 /* XMLKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLKey.swift; sourceTree = "<group>"; };
+		OBJ_50 /* XMLStackParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLStackParser.swift; sourceTree = "<group>"; };
+		OBJ_51 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/maxd/Documents/CoreXLSX/.build/checkouts/XMLCoder.git--8189013463900790701/Package.swift"; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		OBJ_8 /* Package.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Package.xcconfig; sourceTree = "<group>"; };
-		"XMLCoder::XMLCoder::Product" /* XMLCoder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = XMLCoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ZIPFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		OBJ_108 /* Frameworks */ = {
+		OBJ_67 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
+				D15021C521A1C31800BFA4FC /* ZIPFoundation.framework in Frameworks */,
+				D15021C621A1C31800BFA4FC /* XMLCoder.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_126 /* Frameworks */ = {
+		OBJ_94 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_60 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_61 /* ZIPFoundation.framework in Frameworks */,
-				OBJ_62 /* XMLCoder.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_85 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_86 /* CoreXLSX.framework in Frameworks */,
-				OBJ_87 /* ZIPFoundation.framework in Frameworks */,
-				OBJ_88 /* XMLCoder.framework in Frameworks */,
+				D15021C721A1C33E00BFA4FC /* ZIPFoundation.framework in Frameworks */,
+				D15021C821A1C33E00BFA4FC /* XMLCoder.framework in Frameworks */,
+				OBJ_95 /* CoreXLSX.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		D15021C221A1C31800BFA4FC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D15021C421A1C31800BFA4FC /* XMLCoder.framework */,
+				D15021C321A1C31800BFA4FC /* ZIPFoundation.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		OBJ_10 /* CoreXLSX */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_11 /* CoreXLSX.swift */,
-				OBJ_12 /* Relationships.swift */,
-				OBJ_13 /* Worksheet.swift */,
-				D123DC9C219B471D007F6E04 /* ColumnReference.swift */,
-				D123DC9E219C29DD007F6E04 /* CellReference.swift */,
+				OBJ_11 /* CellReference.swift */,
+				OBJ_12 /* ColumnReference.swift */,
+				OBJ_13 /* CoreXLSX.swift */,
+				OBJ_14 /* Relationships.swift */,
+				OBJ_15 /* Worksheet.swift */,
 			);
 			name = CoreXLSX;
 			path = Sources/CoreXLSX;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_14 /* Tests */ = {
+		OBJ_16 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_15 /* CoreXLSXTests */,
+				OBJ_17 /* CoreXLSXTests */,
 			);
 			name = Tests;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_15 /* CoreXLSXTests */ = {
+		OBJ_17 /* CoreXLSXTests */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_16 /* CoreXLSXTests.swift */,
-				OBJ_17 /* XCTestManifests.swift */,
-				D15E8357219D7F0F00EB4544 /* RelationshipsTests.swift */,
-				D15E8359219D87B100EB4544 /* CellReferenceTests.swift */,
+				OBJ_18 /* CellReferenceTests.swift */,
+				OBJ_19 /* CoreXLSXTests.swift */,
+				OBJ_20 /* RelationshipsTests.swift */,
+				OBJ_21 /* XCTestManifests.swift */,
 			);
 			name = CoreXLSXTests;
 			path = Tests/CoreXLSXTests;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_19 /* Dependencies */ = {
+		OBJ_24 /* Dependencies */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_20 /* ZIPFoundation 0.9.6 */,
-				OBJ_30 /* XMLCoder 0.1.0 */,
+				OBJ_25 /* ZIPFoundation 0.9.6 */,
+				OBJ_35 /* XMLCoder 0.1.0 */,
 			);
 			name = Dependencies;
 			sourceTree = "<group>";
 		};
-		OBJ_20 /* ZIPFoundation 0.9.6 */ = {
+		OBJ_25 /* ZIPFoundation 0.9.6 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_21 /* ZIPFoundation */,
-				OBJ_29 /* Package.swift */,
+				OBJ_26 /* ZIPFoundation */,
+				OBJ_34 /* Package.swift */,
 			);
 			name = "ZIPFoundation 0.9.6";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_21 /* ZIPFoundation */ = {
+		OBJ_26 /* ZIPFoundation */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_22 /* Archive+Reading.swift */,
-				OBJ_23 /* Archive+Writing.swift */,
-				OBJ_24 /* Archive.swift */,
-				OBJ_25 /* Data+Compression.swift */,
-				OBJ_26 /* Data+Serialization.swift */,
-				OBJ_27 /* Entry.swift */,
-				OBJ_28 /* FileManager+ZIP.swift */,
+				OBJ_27 /* Archive+Reading.swift */,
+				OBJ_28 /* Archive+Writing.swift */,
+				OBJ_29 /* Archive.swift */,
+				OBJ_30 /* Data+Compression.swift */,
+				OBJ_31 /* Data+Serialization.swift */,
+				OBJ_32 /* Entry.swift */,
+				OBJ_33 /* FileManager+ZIP.swift */,
 			);
 			name = ZIPFoundation;
 			path = ".build/checkouts/ZIPFoundation.git-1553630773966528904/Sources/ZIPFoundation";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_30 /* XMLCoder 0.1.0 */ = {
+		OBJ_35 /* XMLCoder 0.1.0 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_31 /* XMLCoder */,
-				OBJ_46 /* Package.swift */,
+				OBJ_36 /* XMLCoder */,
+				OBJ_51 /* Package.swift */,
 			);
 			name = "XMLCoder 0.1.0";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_31 /* XMLCoder */ = {
+		OBJ_36 /* XMLCoder */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_32 /* Decoder */,
-				OBJ_38 /* Encoder */,
-				OBJ_43 /* ISO8601DateFormatter.swift */,
-				OBJ_44 /* XMLKey.swift */,
-				OBJ_45 /* XMLStackParser.swift */,
+				OBJ_37 /* Decoder */,
+				OBJ_43 /* Encoder */,
+				OBJ_48 /* ISO8601DateFormatter.swift */,
+				OBJ_49 /* XMLKey.swift */,
+				OBJ_50 /* XMLStackParser.swift */,
 			);
 			name = XMLCoder;
 			path = ".build/checkouts/XMLCoder.git--8189013463900790701/Sources/XMLCoder";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_32 /* Decoder */ = {
+		OBJ_37 /* Decoder */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_33 /* DecodingErrorExtension.swift */,
-				OBJ_34 /* XMLDecoder.swift */,
-				OBJ_35 /* XMLDecodingStorage.swift */,
-				OBJ_36 /* XMLKeyedDecodingContainer.swift */,
-				OBJ_37 /* XMLUnkeyedDecodingContainer.swift */,
+				OBJ_38 /* DecodingErrorExtension.swift */,
+				OBJ_39 /* XMLDecoder.swift */,
+				OBJ_40 /* XMLDecodingStorage.swift */,
+				OBJ_41 /* XMLKeyedDecodingContainer.swift */,
+				OBJ_42 /* XMLUnkeyedDecodingContainer.swift */,
 			);
 			path = Decoder;
 			sourceTree = "<group>";
 		};
-		OBJ_38 /* Encoder */ = {
+		OBJ_43 /* Encoder */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_39 /* EncodingErrorExtension.swift */,
-				OBJ_40 /* XMLEncoder.swift */,
-				OBJ_41 /* XMLEncodingStorage.swift */,
-				OBJ_42 /* XMLReferencingEncoder.swift */,
+				OBJ_44 /* EncodingErrorExtension.swift */,
+				OBJ_45 /* XMLEncoder.swift */,
+				OBJ_46 /* XMLEncodingStorage.swift */,
+				OBJ_47 /* XMLReferencingEncoder.swift */,
 			);
 			path = Encoder;
 			sourceTree = "<group>";
 		};
-		OBJ_47 /* Products */ = {
+		OBJ_5 /*  */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Configs */,
+				OBJ_9 /* Sources */,
+				OBJ_16 /* Tests */,
+				OBJ_24 /* Dependencies */,
+				OBJ_52 /* Products */,
+				D15021C221A1C31800BFA4FC /* Frameworks */,
+			);
+			name = "";
+			sourceTree = "<group>";
+		};
+		OBJ_52 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				"CoreXLSX::CoreXLSX::Product" /* CoreXLSX.framework */,
-				"XMLCoder::XMLCoder::Product" /* XMLCoder.framework */,
-				"ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */,
 				"CoreXLSX::CoreXLSXTests::Product" /* CoreXLSXTests.xctest */,
 			);
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		OBJ_5 = {
-			isa = PBXGroup;
-			children = (
-				D123DCA0219C35BA007F6E04 /* CHANGELOG.md */,
-				D155EAF5219ADF9C00D4F47E /* CoreXLSX.podspec */,
-				D155EAF6219ADF9C00D4F47E /* README.md */,
-				OBJ_6 /* Package.swift */,
-				OBJ_7 /* Configs */,
-				OBJ_9 /* Sources */,
-				OBJ_14 /* Tests */,
-				OBJ_18 /* Example */,
-				OBJ_19 /* Dependencies */,
-				OBJ_47 /* Products */,
-			);
-			indentWidth = 2;
-			sourceTree = "<group>";
-			tabWidth = 2;
 		};
 		OBJ_7 /* Configs */ = {
 			isa = PBXGroup;
@@ -345,16 +276,14 @@
 /* Begin PBXNativeTarget section */
 		"CoreXLSX::CoreXLSX" /* CoreXLSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_53 /* Build configuration list for PBXNativeTarget "CoreXLSX" */;
+			buildConfigurationList = OBJ_58 /* Build configuration list for PBXNativeTarget "CoreXLSX" */;
 			buildPhases = (
-				OBJ_56 /* Sources */,
-				OBJ_60 /* Frameworks */,
+				OBJ_61 /* Sources */,
+				OBJ_67 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_63 /* PBXTargetDependency */,
-				OBJ_65 /* PBXTargetDependency */,
 			);
 			name = CoreXLSX;
 			productName = CoreXLSX;
@@ -363,17 +292,16 @@
 		};
 		"CoreXLSX::CoreXLSXTests" /* CoreXLSXTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_79 /* Build configuration list for PBXNativeTarget "CoreXLSXTests" */;
+			buildConfigurationList = OBJ_86 /* Build configuration list for PBXNativeTarget "CoreXLSXTests" */;
 			buildPhases = (
-				OBJ_82 /* Sources */,
-				OBJ_85 /* Frameworks */,
+				OBJ_89 /* Sources */,
+				OBJ_94 /* Frameworks */,
+				D15021C921A1C3BB00BFA4FC /* CopyFiles */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_89 /* PBXTargetDependency */,
-				OBJ_90 /* PBXTargetDependency */,
-				OBJ_91 /* PBXTargetDependency */,
+				OBJ_98 /* PBXTargetDependency */,
 			);
 			name = CoreXLSXTests;
 			productName = CoreXLSXTests;
@@ -382,9 +310,9 @@
 		};
 		"CoreXLSX::SwiftPMPackageDescription" /* CoreXLSXPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_68 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */;
+			buildConfigurationList = OBJ_75 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */;
 			buildPhases = (
-				OBJ_71 /* Sources */,
+				OBJ_78 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -392,66 +320,6 @@
 			);
 			name = CoreXLSXPackageDescription;
 			productName = CoreXLSXPackageDescription;
-			productType = "com.apple.product-type.framework";
-		};
-		"XMLCoder::SwiftPMPackageDescription" /* XMLCoderPackageDescription */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_110 /* Build configuration list for PBXNativeTarget "XMLCoderPackageDescription" */;
-			buildPhases = (
-				OBJ_113 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = XMLCoderPackageDescription;
-			productName = XMLCoderPackageDescription;
-			productType = "com.apple.product-type.framework";
-		};
-		"XMLCoder::XMLCoder" /* XMLCoder */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_92 /* Build configuration list for PBXNativeTarget "XMLCoder" */;
-			buildPhases = (
-				OBJ_95 /* Sources */,
-				OBJ_108 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = XMLCoder;
-			productName = XMLCoder;
-			productReference = "XMLCoder::XMLCoder::Product" /* XMLCoder.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		"ZIPFoundation::SwiftPMPackageDescription" /* ZIPFoundationPackageDescription */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_128 /* Build configuration list for PBXNativeTarget "ZIPFoundationPackageDescription" */;
-			buildPhases = (
-				OBJ_131 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = ZIPFoundationPackageDescription;
-			productName = ZIPFoundationPackageDescription;
-			productType = "com.apple.product-type.framework";
-		};
-		"ZIPFoundation::ZIPFoundation" /* ZIPFoundation */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_115 /* Build configuration list for PBXNativeTarget "ZIPFoundation" */;
-			buildPhases = (
-				OBJ_118 /* Sources */,
-				OBJ_126 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = ZIPFoundation;
-			productName = ZIPFoundation;
-			productReference = "ZIPFoundation::ZIPFoundation::Product" /* ZIPFoundation.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -469,226 +337,61 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5;
-			productRefGroup = OBJ_47 /* Products */;
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_52 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				"CoreXLSX::CoreXLSX" /* CoreXLSX */,
 				"CoreXLSX::SwiftPMPackageDescription" /* CoreXLSXPackageDescription */,
-				"CoreXLSX::CoreXLSXPackageTests::ProductTarget" /* CoreXLSXPackageTests */,
 				"CoreXLSX::CoreXLSXTests" /* CoreXLSXTests */,
-				"XMLCoder::XMLCoder" /* XMLCoder */,
-				"XMLCoder::SwiftPMPackageDescription" /* XMLCoderPackageDescription */,
-				"ZIPFoundation::ZIPFoundation" /* ZIPFoundation */,
-				"ZIPFoundation::SwiftPMPackageDescription" /* ZIPFoundationPackageDescription */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		OBJ_113 /* Sources */ = {
+		OBJ_61 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_114 /* Package.swift in Sources */,
+				OBJ_62 /* CellReference.swift in Sources */,
+				OBJ_63 /* ColumnReference.swift in Sources */,
+				OBJ_64 /* CoreXLSX.swift in Sources */,
+				OBJ_65 /* Relationships.swift in Sources */,
+				OBJ_66 /* Worksheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_118 /* Sources */ = {
+		OBJ_78 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_119 /* Archive+Reading.swift in Sources */,
-				OBJ_120 /* Archive+Writing.swift in Sources */,
-				OBJ_121 /* Archive.swift in Sources */,
-				OBJ_122 /* Data+Compression.swift in Sources */,
-				OBJ_123 /* Data+Serialization.swift in Sources */,
-				OBJ_124 /* Entry.swift in Sources */,
-				OBJ_125 /* FileManager+ZIP.swift in Sources */,
+				OBJ_79 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_131 /* Sources */ = {
+		OBJ_89 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_132 /* Package.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_56 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_57 /* CoreXLSX.swift in Sources */,
-				D123DC9D219B471D007F6E04 /* ColumnReference.swift in Sources */,
-				D123DC9F219C29DD007F6E04 /* CellReference.swift in Sources */,
-				OBJ_58 /* Relationships.swift in Sources */,
-				OBJ_59 /* Worksheet.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_71 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_72 /* Package.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_82 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_83 /* CoreXLSXTests.swift in Sources */,
-				D15E835A219D87B100EB4544 /* CellReferenceTests.swift in Sources */,
-				OBJ_84 /* XCTestManifests.swift in Sources */,
-				D15E8358219D7F0F00EB4544 /* RelationshipsTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_95 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_96 /* DecodingErrorExtension.swift in Sources */,
-				OBJ_97 /* XMLDecoder.swift in Sources */,
-				OBJ_98 /* XMLDecodingStorage.swift in Sources */,
-				OBJ_99 /* XMLKeyedDecodingContainer.swift in Sources */,
-				OBJ_100 /* XMLUnkeyedDecodingContainer.swift in Sources */,
-				OBJ_101 /* EncodingErrorExtension.swift in Sources */,
-				OBJ_102 /* XMLEncoder.swift in Sources */,
-				OBJ_103 /* XMLEncodingStorage.swift in Sources */,
-				OBJ_104 /* XMLReferencingEncoder.swift in Sources */,
-				OBJ_105 /* ISO8601DateFormatter.swift in Sources */,
-				OBJ_106 /* XMLKey.swift in Sources */,
-				OBJ_107 /* XMLStackParser.swift in Sources */,
+				OBJ_90 /* CellReferenceTests.swift in Sources */,
+				OBJ_91 /* CoreXLSXTests.swift in Sources */,
+				OBJ_92 /* RelationshipsTests.swift in Sources */,
+				OBJ_93 /* XCTestManifests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		OBJ_63 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "ZIPFoundation::ZIPFoundation" /* ZIPFoundation */;
-			targetProxy = D155EAEF219ADA9E00D4F47E /* PBXContainerItemProxy */;
-		};
-		OBJ_65 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "XMLCoder::XMLCoder" /* XMLCoder */;
-			targetProxy = D155EAF0219ADA9E00D4F47E /* PBXContainerItemProxy */;
-		};
-		OBJ_77 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "CoreXLSX::CoreXLSXTests" /* CoreXLSXTests */;
-			targetProxy = D155EAF4219ADA9E00D4F47E /* PBXContainerItemProxy */;
-		};
-		OBJ_89 /* PBXTargetDependency */ = {
+		OBJ_98 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "CoreXLSX::CoreXLSX" /* CoreXLSX */;
-			targetProxy = D155EAF1219ADA9E00D4F47E /* PBXContainerItemProxy */;
-		};
-		OBJ_90 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "ZIPFoundation::ZIPFoundation" /* ZIPFoundation */;
-			targetProxy = D155EAF2219ADA9E00D4F47E /* PBXContainerItemProxy */;
-		};
-		OBJ_91 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "XMLCoder::XMLCoder" /* XMLCoder */;
-			targetProxy = D155EAF3219ADA9E00D4F47E /* PBXContainerItemProxy */;
+			targetProxy = D15021BE21A1C23700BFA4FC /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		OBJ_111 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.0;
-			};
-			name = Debug;
-		};
-		OBJ_112 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.0;
-			};
-			name = Release;
-		};
-		OBJ_116 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = CoreXLSX.xcodeproj/ZIPFoundation_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = ZIPFoundation;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.0;
-				TARGET_NAME = ZIPFoundation;
-			};
-			name = Debug;
-		};
-		OBJ_117 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = CoreXLSX.xcodeproj/ZIPFoundation_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = ZIPFoundation;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.0;
-				TARGET_NAME = ZIPFoundation;
-			};
-			name = Release;
-		};
-		OBJ_129 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.0;
-			};
-			name = Debug;
-		};
-		OBJ_130 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.0;
-			};
-			name = Release;
-		};
 		OBJ_3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -735,7 +438,7 @@
 			};
 			name = Release;
 		};
-		OBJ_54 /* Debug */ = {
+		OBJ_59 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
 			buildSettings = {
@@ -743,6 +446,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSX_Info.plist;
@@ -760,7 +464,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_55 /* Release */ = {
+		OBJ_60 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
 			buildSettings = {
@@ -768,6 +472,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSX_Info.plist;
@@ -785,7 +490,7 @@
 			};
 			name = Release;
 		};
-		OBJ_69 /* Debug */ = {
+		OBJ_76 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
@@ -794,7 +499,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_70 /* Release */ = {
+		OBJ_77 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
@@ -803,19 +508,7 @@
 			};
 			name = Release;
 		};
-		OBJ_75 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		OBJ_76 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		OBJ_80 /* Debug */ = {
+		OBJ_87 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
 			buildSettings = {
@@ -824,6 +517,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXTests_Info.plist;
@@ -837,7 +531,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_81 /* Release */ = {
+		OBJ_88 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
 			buildSettings = {
@@ -846,6 +540,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = CoreXLSX.xcodeproj/CoreXLSXTests_Info.plist;
@@ -856,89 +551,12 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 4.2;
 				TARGET_NAME = CoreXLSXTests;
-			};
-			name = Release;
-		};
-		OBJ_93 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = CoreXLSX.xcodeproj/XMLCoder_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = XMLCoder;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.0;
-				TARGET_NAME = XMLCoder;
-			};
-			name = Debug;
-		};
-		OBJ_94 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = OBJ_8 /* Package.xcconfig */;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = CoreXLSX.xcodeproj/XMLCoder_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = XMLCoder;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.0;
-				TARGET_NAME = XMLCoder;
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		OBJ_110 /* Build configuration list for PBXNativeTarget "XMLCoderPackageDescription" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_111 /* Debug */,
-				OBJ_112 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_115 /* Build configuration list for PBXNativeTarget "ZIPFoundation" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_116 /* Debug */,
-				OBJ_117 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_128 /* Build configuration list for PBXNativeTarget "ZIPFoundationPackageDescription" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_129 /* Debug */,
-				OBJ_130 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		OBJ_2 /* Build configuration list for PBXProject "CoreXLSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -948,47 +566,29 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_53 /* Build configuration list for PBXNativeTarget "CoreXLSX" */ = {
+		OBJ_58 /* Build configuration list for PBXNativeTarget "CoreXLSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_54 /* Debug */,
-				OBJ_55 /* Release */,
+				OBJ_59 /* Debug */,
+				OBJ_60 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_68 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */ = {
+		OBJ_75 /* Build configuration list for PBXNativeTarget "CoreXLSXPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_69 /* Debug */,
-				OBJ_70 /* Release */,
+				OBJ_76 /* Debug */,
+				OBJ_77 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_74 /* Build configuration list for PBXAggregateTarget "CoreXLSXPackageTests" */ = {
+		OBJ_86 /* Build configuration list for PBXNativeTarget "CoreXLSXTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_75 /* Debug */,
-				OBJ_76 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_79 /* Build configuration list for PBXNativeTarget "CoreXLSXTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_80 /* Debug */,
-				OBJ_81 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_92 /* Build configuration list for PBXNativeTarget "XMLCoder" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_93 /* Debug */,
-				OBJ_94 /* Release */,
+				OBJ_87 /* Debug */,
+				OBJ_88 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/CoreXLSX.xcodeproj/xcshareddata/xcschemes/CoreXLSXiOS.xcscheme
+++ b/CoreXLSX.xcodeproj/xcshareddata/xcschemes/CoreXLSXiOS.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D15021D021A1CA7D00BFA4FC"
+               BlueprintIdentifier = "D15021EE21A1D11900BFA4FC"
                BuildableName = "CoreXLSX.framework"
-               BlueprintName = "CoreXLSXtvOS"
+               BlueprintName = "CoreXLSXiOS"
                ReferencedContainer = "container:CoreXLSX.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -29,15 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D15021D021A1CA7D00BFA4FC"
-            BuildableName = "CoreXLSX.framework"
-            BlueprintName = "CoreXLSXtvOS"
-            ReferencedContainer = "container:CoreXLSX.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -54,9 +45,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D15021D021A1CA7D00BFA4FC"
+            BlueprintIdentifier = "D15021EE21A1D11900BFA4FC"
             BuildableName = "CoreXLSX.framework"
-            BlueprintName = "CoreXLSXtvOS"
+            BlueprintName = "CoreXLSXiOS"
             ReferencedContainer = "container:CoreXLSX.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -72,9 +63,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D15021D021A1CA7D00BFA4FC"
+            BlueprintIdentifier = "D15021EE21A1D11900BFA4FC"
             BuildableName = "CoreXLSX.framework"
-            BlueprintName = "CoreXLSXtvOS"
+            BlueprintName = "CoreXLSXiOS"
             ReferencedContainer = "container:CoreXLSX.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/CoreXLSX.xcodeproj/xcshareddata/xcschemes/CoreXLSXmacOS.xcscheme
+++ b/CoreXLSX.xcodeproj/xcshareddata/xcschemes/CoreXLSXmacOS.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CoreXLSX::CoreXLSX"
                BuildableName = "CoreXLSX.framework"
-               BlueprintName = "CoreXLSX"
+               BlueprintName = "CoreXLSXmacOS"
                ReferencedContainer = "container:CoreXLSX.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -40,6 +40,15 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CoreXLSX::CoreXLSX"
+            BuildableName = "CoreXLSX.framework"
+            BlueprintName = "CoreXLSXmacOS"
+            ReferencedContainer = "container:CoreXLSX.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -58,7 +67,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CoreXLSX::CoreXLSX"
             BuildableName = "CoreXLSX.framework"
-            BlueprintName = "CoreXLSX"
+            BlueprintName = "CoreXLSXmacOS"
             ReferencedContainer = "container:CoreXLSX.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -78,6 +87,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CoreXLSX::CoreXLSX"
+            BuildableName = "CoreXLSX.framework"
+            BlueprintName = "CoreXLSXmacOS"
+            ReferencedContainer = "container:CoreXLSX.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/CoreXLSX.xcodeproj/xcshareddata/xcschemes/CoreXLSXtvOS.xcscheme
+++ b/CoreXLSX.xcodeproj/xcshareddata/xcschemes/CoreXLSXtvOS.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D15021D021A1CA7D00BFA4FC"
+               BuildableName = "CoreXLSXtvOS.framework"
+               BlueprintName = "CoreXLSXtvOS"
+               ReferencedContainer = "container:CoreXLSX.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D15021D021A1CA7D00BFA4FC"
+            BuildableName = "CoreXLSXtvOS.framework"
+            BlueprintName = "CoreXLSXtvOS"
+            ReferencedContainer = "container:CoreXLSX.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D15021D021A1CA7D00BFA4FC"
+            BuildableName = "CoreXLSXtvOS.framework"
+            BlueprintName = "CoreXLSXtvOS"
+            ReferencedContainer = "container:CoreXLSX.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D15021D021A1CA7D00BFA4FC"
+            BuildableName = "CoreXLSXtvOS.framework"
+            BlueprintName = "CoreXLSXtvOS"
+            ReferencedContainer = "container:CoreXLSX.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CoreXLSX.xcodeproj/xcshareddata/xcschemes/CoreXLSXwatchOS.xcscheme
+++ b/CoreXLSX.xcodeproj/xcshareddata/xcschemes/CoreXLSXwatchOS.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D15021D021A1CA7D00BFA4FC"
+               BlueprintIdentifier = "D150220421A1D8DC00BFA4FC"
                BuildableName = "CoreXLSX.framework"
-               BlueprintName = "CoreXLSXtvOS"
+               BlueprintName = "CoreXLSXwatchOS"
                ReferencedContainer = "container:CoreXLSX.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -29,15 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D15021D021A1CA7D00BFA4FC"
-            BuildableName = "CoreXLSX.framework"
-            BlueprintName = "CoreXLSXtvOS"
-            ReferencedContainer = "container:CoreXLSX.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -54,9 +45,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D15021D021A1CA7D00BFA4FC"
+            BlueprintIdentifier = "D150220421A1D8DC00BFA4FC"
             BuildableName = "CoreXLSX.framework"
-            BlueprintName = "CoreXLSXtvOS"
+            BlueprintName = "CoreXLSXwatchOS"
             ReferencedContainer = "container:CoreXLSX.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -72,9 +63,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D15021D021A1CA7D00BFA4FC"
+            BlueprintIdentifier = "D150220421A1D8DC00BFA4FC"
             BuildableName = "CoreXLSX.framework"
-            BlueprintName = "CoreXLSXtvOS"
+            BlueprintName = "CoreXLSXwatchOS"
             ReferencedContainer = "container:CoreXLSX.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
     .package(url: "https://github.com/maxdesiatov/XMLCoder.git",
-             .upToNextMajor(from: "0.1.0")),
+             .upToNextMajor(from: "0.2.1")),
     .package(url: "https://github.com/weichsel/ZIPFoundation.git",
              .upToNextMajor(from: "0.9.0")),
   ],

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![License](https://img.shields.io/cocoapods/l/CoreXLSX.svg?style=flat)](https://cocoapods.org/pods/CoreXLSX)
 [![Platform](https://img.shields.io/cocoapods/p/CoreXLSX.svg?style=flat)](https://cocoapods.org/pods/CoreXLSX)
 [![Coverage](https://img.shields.io/codecov/c/github/MaxDesiatov/CoreXLSX/master.svg?style=flat)](https://codecov.io/gh/maxdesiatov/CoreXLSX)
+[![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 ## Example
 
@@ -54,7 +56,9 @@ here](https://desiatov.com/swift-codable-xlsx/).
 
 ## Requirements
 
-Xcode 10, Swift 4.2, iOS 9.0 or macOS 10.11
+* Xcode 10
+* Swift 4.2
+* iOS 9.0 / watchOS 2.0 / tvOS 9.0 / macOS 10.11  
 
 ## Installation
 
@@ -83,6 +87,30 @@ it, simply add the following line to your `Podfile`:
 ```ruby
 pod 'CoreXLSX'
 ```
+### Carthage
+
+[Carthage](https://github.com/Carthage/Carthage) is a dependency manager that builds your dependencies and provides you with binary frameworks.
+
+Carthage can be installed with [Homebrew](https://brew.sh/) using the following command:
+
+```bash
+$ brew update
+$ brew install carthage
+```
+
+Inside of your `Cartfile`, add GitHub path to `CoreXLSX`:
+
+```ogdl
+github "MaxDesiatov/CoreXLSX" ~> 0.3.0
+```
+
+Then, run the following command to build the framework:
+
+```bash
+$ carthage update
+```
+
+Drag the built frameworks (including the subdependencies `XMLCoder` and `ZIPFoundation` into your Xcode project.
 
 ## Author
 


### PR DESCRIPTION
By default Carthage tries to build for all platforms marked as "supported" in the Xcode project, so this was a good excuse to add that the podspec as well. Carthage support was fixed by adding a per-platform target in the Xcode project and linking correct dependencies for every platform in settings of each target.

Resolves #4.