### PR TITLE
Add API for filtering cells by rows and columns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
 - xcodebuild -scheme CoreXLSXiOS
 - xcodebuild -scheme CoreXLSXwatchOS
 - xcodebuild -scheme CoreXLSXtvOS
+- rm -rf /Users/travis/Library/Developer/Xcode/DerivedData/
 - xcodebuild test -enableCodeCoverage YES -scheme CoreXLSXmacOS
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_install:
 script:
 - pod lib lint
 - carthage update
-- xcodebuild test -enableCodeCoverage YES -scheme CoreXLSXmacOS
 - xcodebuild -scheme CoreXLSXiOS
 - xcodebuild -scheme CoreXLSXwatchOS
 - xcodebuild -scheme CoreXLSXtvOS
+- xcodebuild test -enableCodeCoverage YES -scheme CoreXLSXmacOS
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/CoreXLSX.xcodeproj/project.pbxproj
+++ b/CoreXLSX.xcodeproj/project.pbxproj
@@ -175,10 +175,8 @@
 		D15021C221A1C31800BFA4FC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				D15021F721A1D1A500BFA4FC /* XMLCoder.framework */,
-				D15021F821A1D1A500BFA4FC /* ZIPFoundation.framework */,
-				D150220D21A1D95400BFA4FC /* XMLCoder.framework */,
-				D150220E21A1D95400BFA4FC /* ZIPFoundation.framework */,
+				D15BA1B921A1EC6A00CB3C7B /* iOS */,
+				D15BA1BA21A1EC7C00CB3C7B /* watchOS */,
 				D15021E921A1CB7700BFA4FC /* macOS */,
 				D15021E821A1CB6300BFA4FC /* tvOS */,
 			);
@@ -201,6 +199,24 @@
 				D15021C321A1C31800BFA4FC /* ZIPFoundation.framework */,
 			);
 			name = macOS;
+			sourceTree = "<group>";
+		};
+		D15BA1B921A1EC6A00CB3C7B /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				D15021F721A1D1A500BFA4FC /* XMLCoder.framework */,
+				D15021F821A1D1A500BFA4FC /* ZIPFoundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		D15BA1BA21A1EC7C00CB3C7B /* watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				D150220D21A1D95400BFA4FC /* XMLCoder.framework */,
+				D150220E21A1D95400BFA4FC /* ZIPFoundation.framework */,
+			);
+			name = watchOS;
 			sourceTree = "<group>";
 		};
 		OBJ_10 /* CoreXLSX */ = {

--- a/Sources/CoreXLSX/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet.swift
@@ -32,21 +32,33 @@ public struct Worksheet: Codable {
     case mergeCells
   }
 
-  /// Return all cells that are contained in a given worksheet and set of
+  /// Return all cells that are contained in a given worksheet and collection of
   /// columns.
-  public func cells<T>(atColumns: T) -> [Cell]
+  public func cells<T>(atColumns columns: T) -> [Cell]
   where T: Collection, T.Element == ColumnReference {
     return sheetData.rows.map {
-      return $0.cells.filter { atColumns.contains($0.reference.column) }
+      return $0.cells.filter { columns.contains($0.reference.column) }
     }
     .reduce([]) { $0 + $1 }
   }
 
-  /// Return all cells that are contained in a given worksheet and set of rows.
+  /// Return all cells that are contained in a given worksheet and collection of
+  /// rows.
   public func cells<T>(atRows rows: T) -> [Cell]
   where T: Collection, T.Element == UInt {
     return sheetData.rows.filter { rows.contains($0.reference) }
       .reduce([]) { $0 + $1.cells }
+  }
+
+  /// Return all cells that are contained in a given worksheet and collections
+  /// of rows and columns.
+  public func cells<T1, T2>(atColumns columns: T1, rows: T2) -> [Cell]
+    where T1: Collection, T1.Element == ColumnReference,
+    T2: Collection, T2.Element == UInt {
+      return sheetData.rows.filter { rows.contains($0.reference) }.map {
+        return $0.cells.filter { columns.contains($0.reference.column) }
+      }
+      .reduce([]) { $0 + $1 }
   }
 }
 

--- a/Tests/CoreXLSXTests/CoreXLSXTests.swift
+++ b/Tests/CoreXLSXTests/CoreXLSXTests.swift
@@ -37,8 +37,14 @@ final class XLSXReaderTests: XCTestCase {
 
       XCTAssertEqual(allCells, ws.cells(atColumns: columnReferences))
 
-      let closedRange = ColumnReference("A")!...ColumnReference("F")!
-      XCTAssertEqual(allCells, ws.cells(atColumns: closedRange))
+      let closedRange1 = ColumnReference("A")!...ColumnReference("F")!
+      XCTAssertEqual(allCells, ws.cells(atColumns: closedRange1))
+
+      let closedRange2 = ColumnReference("A")!...ColumnReference("C")!
+      let rowsRange: ClosedRange<UInt> = 3...10
+      let cellsInRange = ws.cells(atColumns: closedRange2, rows: rowsRange)
+      print(cellsInRange)
+      XCTAssertEqual(cellsInRange.count, closedRange2.count * rowsRange.count)
     } catch {
       XCTAssert(false, "unexpected error \(error)")
     }


### PR DESCRIPTION
There are APIs to filter cells by rows and columns separately, but no API for filtering by both criteria at the same time. This is added with an implementation similar to those previous APIs with new assertions in tests.