### PR TITLE
Make `columns` property optional on `Worksheet`

### DIFF
--- a/Sources/CoreXLSX/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet.swift
@@ -12,10 +12,10 @@ public struct Worksheet: Codable {
   public let dimension: WorksheetDimension
   public let sheetViews: SheetViews
   public let sheetFormatPr: SheetFormatPr
-  public let columns: Columns
+  public let columns: Columns?
 
   @available(*, deprecated, renamed: "columns")
-  public var cols: Cols {
+  public var cols: Cols? {
     return columns
   }
 


### PR DESCRIPTION
As reported in #12, there are worksheets that apparently don't have `cols` node, which means that `columns` property on `Worksheet` should be optional.