### PR TITLE
Add simple `Workbook` model with tests

### DIFF
--- a/CoreXLSX.xcodeproj/project.pbxproj
+++ b/CoreXLSX.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		D150221321A1D97E00BFA4FC /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* CoreXLSX.swift */; };
 		D150221421A1D97E00BFA4FC /* Relationships.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* Relationships.swift */; };
 		D150221521A1D97E00BFA4FC /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Worksheet.swift */; };
+		D1C96B8021A806A500303975 /* Workbook.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C96B7F21A806A500303975 /* Workbook.swift */; };
+		D1C96B8321A80EC000303975 /* WorkbookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C96B8121A80E5900303975 /* WorkbookTests.swift */; };
 		OBJ_62 /* CellReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* CellReference.swift */; };
 		OBJ_63 /* ColumnReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* ColumnReference.swift */; };
 		OBJ_64 /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* CoreXLSX.swift */; };
@@ -89,6 +91,8 @@
 		D150220521A1D8DC00BFA4FC /* CoreXLSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreXLSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D150220D21A1D95400BFA4FC /* XMLCoder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XMLCoder.framework; path = Carthage/Build/watchOS/XMLCoder.framework; sourceTree = "<group>"; };
 		D150220E21A1D95400BFA4FC /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/watchOS/ZIPFoundation.framework; sourceTree = "<group>"; };
+		D1C96B7F21A806A500303975 /* Workbook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workbook.swift; sourceTree = "<group>"; };
+		D1C96B8121A80E5900303975 /* WorkbookTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkbookTests.swift; sourceTree = "<group>"; };
 		OBJ_11 /* CellReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellReference.swift; sourceTree = "<group>"; };
 		OBJ_12 /* ColumnReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnReference.swift; sourceTree = "<group>"; };
 		OBJ_13 /* CoreXLSX.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreXLSX.swift; sourceTree = "<group>"; };
@@ -227,6 +231,7 @@
 				OBJ_13 /* CoreXLSX.swift */,
 				OBJ_14 /* Relationships.swift */,
 				OBJ_15 /* Worksheet.swift */,
+				D1C96B7F21A806A500303975 /* Workbook.swift */,
 			);
 			name = CoreXLSX;
 			path = Sources/CoreXLSX;
@@ -247,6 +252,7 @@
 				OBJ_19 /* CoreXLSXTests.swift */,
 				OBJ_20 /* RelationshipsTests.swift */,
 				OBJ_21 /* XCTestManifests.swift */,
+				D1C96B8121A80E5900303975 /* WorkbookTests.swift */,
 			);
 			name = CoreXLSXTests;
 			path = Tests/CoreXLSXTests;
@@ -604,6 +610,7 @@
 				OBJ_64 /* CoreXLSX.swift in Sources */,
 				OBJ_65 /* Relationships.swift in Sources */,
 				OBJ_66 /* Worksheet.swift in Sources */,
+				D1C96B8021A806A500303975 /* Workbook.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -611,6 +618,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				D1C96B8321A80EC000303975 /* WorkbookTests.swift in Sources */,
 				OBJ_90 /* CellReferenceTests.swift in Sources */,
 				OBJ_91 /* CoreXLSXTests.swift in Sources */,
 				OBJ_92 /* RelationshipsTests.swift in Sources */,

--- a/Sources/CoreXLSX/CoreXLSX.swift
+++ b/Sources/CoreXLSX/CoreXLSX.swift
@@ -53,6 +53,14 @@ public struct XLSXFile {
       .map { $0.target }
   }
 
+  public func parseWorkbooks() throws -> [Workbook] {
+    decoder.keyDecodingStrategy = .useDefaultKeys
+
+    return try parseDocumentPaths().map {
+      return try parseEntry($0, Workbook.self)
+    }
+  }
+
   /// Parse and return an array of worksheets in this XLSX file.
   public func parseWorksheetPaths() throws -> [String] {
     decoder.keyDecodingStrategy = .convertFromCapitalized

--- a/Sources/CoreXLSX/Workbook.swift
+++ b/Sources/CoreXLSX/Workbook.swift
@@ -1,0 +1,52 @@
+//
+//  Workbook.swift
+//  CoreXLSXmacOS
+//
+//  Created by Max Desiatov on 23/11/2018.
+//
+
+public struct Workbook: Codable, Equatable {
+  public struct Views: Codable, Equatable {
+    public let items: [View]
+
+    enum CodingKeys: String, CodingKey {
+      case items = "workbookView"
+    }
+  }
+
+  public struct View: Codable, Equatable {
+    public let xWindow: Int
+    public let yWindow: Int
+    public let windowWidth: UInt
+    public let windowHeight: UInt
+  }
+
+  public let views: Views
+
+  public struct Sheets: Codable, Equatable {
+    public let items: [Sheet]
+
+    enum CodingKeys: String, CodingKey {
+      case items = "sheet"
+    }
+  }
+
+  public struct Sheet: Codable, Equatable {
+    public let name: String?
+    public let id: String
+    public let relationship: String
+
+    enum CodingKeys: String, CodingKey {
+      case name = "name"
+      case id = "sheetId"
+      case relationship = "r:id"
+    }
+  }
+
+  public let sheets: Sheets
+
+  enum CodingKeys: String, CodingKey {
+    case views = "bookViews"
+    case sheets
+  }
+}

--- a/Tests/CoreXLSXTests/CoreXLSXTests.swift
+++ b/Tests/CoreXLSXTests/CoreXLSXTests.swift
@@ -1,8 +1,9 @@
 import XCTest
 @testable import CoreXLSX
 
+let currentWorkingPath = ProcessInfo.processInfo.environment["TESTS_PATH"]!
+
 final class XLSXReaderTests: XCTestCase {
-  let currentWorkingPath = ProcessInfo.processInfo.environment["TESTS_PATH"]!
   let sheetPath = "xl/worksheets/sheet1.xml"
 
   func testPublicAPI() {

--- a/Tests/CoreXLSXTests/WorkbookTests.swift
+++ b/Tests/CoreXLSXTests/WorkbookTests.swift
@@ -1,0 +1,36 @@
+//
+//  WorkbookTests.swift
+//  CoreXLSXmacOS
+//
+//  Created by Max Desiatov on 23/11/2018.
+//
+
+import XCTest
+@testable import CoreXLSX
+
+private let parsed = [
+  Workbook.Sheet(name: "Sheet 1",
+                 id: "1",
+                 relationship: "rId4")
+]
+
+final class WorkbookTests: XCTestCase {
+  func testWorkbook() {
+    guard let file =
+      XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
+        XCTAssert(false, "failed to open the file")
+        return
+    }
+
+    do {
+      let wbs = try file.parseWorkbooks()
+      XCTAssertEqual(wbs[0].sheets.items, parsed)
+    } catch {
+      XCTAssert(false, "unexpected error \(error)")
+    }
+  }
+
+  static let allTests = [
+    ("testWorkbook", testWorkbook),
+  ]
+}

--- a/Tests/CoreXLSXTests/XCTestManifests.swift
+++ b/Tests/CoreXLSXTests/XCTestManifests.swift
@@ -6,6 +6,7 @@ public func allTests() -> [XCTestCaseEntry] {
     testCase(CoreXLSXTests.allTests),
     testCase(RelationshipsTests.allTests),
     testCase(CellReferenceTests.allTests),
+    testCase(WorkbookTests.allTests),
   ]
 }
 #endif


### PR DESCRIPTION
As reported in #10, currently there is no way to get a worksheet name. This can be fixed by parsing workbook files. Proposed approach here is to add `parseWorkbooks` API on `XLSXFile` and a new `Workbook` model.