### PR TITLE
Rename sheetData on Worksheet and make it optional

### DIFF
--- a/Sources/CoreXLSX/CoreXLSX.swift
+++ b/Sources/CoreXLSX/CoreXLSX.swift
@@ -88,8 +88,8 @@ public struct XLSXFile {
   -> [Cell] {
     let ws = try parseWorksheet(at: path)
 
-    return ws.sheetData.rows.filter { rows.contains(Int($0.reference)) }
-      .reduce([]) { $0 + $1.cells }
+    return ws.data?.rows.filter { rows.contains(Int($0.reference)) }
+      .reduce([]) { $0 + $1.cells } ?? []
   }
 
   /// Return all cells that are contained in a given worksheet and set of
@@ -101,7 +101,7 @@ public struct XLSXFile {
   -> [Cell] {
     let ws = try parseWorksheet(at: path)
 
-    return ws.sheetData.rows.map {
+    return ws.data?.rows.map {
       let rowReference = $0.reference
       let targetReferences = columns.compactMap {
       (c: String) -> CellReference? in
@@ -110,6 +110,6 @@ public struct XLSXFile {
       }
       return $0.cells.filter { targetReferences.contains($0.reference) }
     }
-    .reduce([]) { $0 + $1 }
+    .reduce([]) { $0 + $1 } ?? []
   }
 }

--- a/Sources/CoreXLSX/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet.swift
@@ -32,7 +32,7 @@ public struct Worksheet: Codable {
 
   public let data: Data?
 
-  @available(*, deprecated, renamed: "columns")
+  @available(*, deprecated, renamed: "data")
   public var sheetData: SheetData {
     return data ?? Data(rows: [])
   }

--- a/Tests/CoreXLSXTests/CoreXLSXTests.swift
+++ b/Tests/CoreXLSXTests/CoreXLSXTests.swift
@@ -17,12 +17,16 @@ final class XLSXReaderTests: XCTestCase {
       XCTAssertEqual(try file.parseWorksheetPaths(), [sheetPath])
 
       let ws = try file.parseWorksheet(at: sheetPath)
-      let allCells = ws.sheetData.rows
+      guard let sd = ws.data else {
+        XCTAssert(false, "no sheet data available")
+        return
+      }
+      let allCells = sd.rows
         .map { $0.cells }
         .reduce([], { $0 + $1 })
       XCTAssertEqual(allCells.count, 90)
 
-      let rowReferences = ws.sheetData.rows.map { $0.reference }
+      let rowReferences = sd.rows.map { $0.reference }
       let cellsFromRows = ws.cells(atRows: rowReferences)
       XCTAssertEqual(allCells, cellsFromRows)
 


### PR DESCRIPTION
As previously reported, there are Excel documents in the wild that contain no `sheetData` node. While I was no able to recreate these sheets, I assume these still can be generated by some tools or apps. They do make sense as empty worksheets, so let's allow these in the `Worksheet` model type. To cleanup the naming a new non-optional property `data` has been added. The previous name and type are aliased for source compatibility with a deprecation warning.

Resolves #15 