### PR TITLE
Make Relationships public, add parseRelationships

### DIFF
--- a/Sources/CoreXLSX/CoreXLSX.swift
+++ b/Sources/CoreXLSX/CoreXLSX.swift
@@ -51,11 +51,15 @@ public struct XLSXFile {
     return result!
   }
 
-  /// Return an array of paths to relationships of type `officeDocument`
-  func parseDocumentPaths() throws -> [String] {
+  public func parseRelationships() throws -> Relationships {
     decoder.keyDecodingStrategy = .convertFromCapitalized
 
-    return try parseEntry("_rels/.rels", Relationships.self).items
+    return try parseEntry("_rels/.rels", Relationships.self)
+  }
+
+  /// Return an array of paths to relationships of type `officeDocument`
+  func parseDocumentPaths() throws -> [String] {
+    return try parseRelationships().items
       .filter { $0.type == .officeDocument }
       .map { $0.target }
   }

--- a/Sources/CoreXLSX/Relationships.swift
+++ b/Sources/CoreXLSX/Relationships.swift
@@ -5,16 +5,16 @@
 //  Created by Max Desiatov on 27/10/2018.
 //
 
-struct Relationships: Codable {
-  let items: [Relationship]
+public struct Relationships: Codable, Equatable {
+  public let items: [Relationship]
 
   enum CodingKeys: String, CodingKey {
     case items = "relationship"
   }
 }
 
-struct Relationship: Codable, Equatable {
-  enum SchemaType: String, Codable {
+public struct Relationship: Codable, Equatable {
+  public enum SchemaType: String, Codable {
     case officeDocument = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
     case extendedProperties = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties"
     case coreProperties = "http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties"
@@ -24,7 +24,7 @@ struct Relationship: Codable, Equatable {
     case theme = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme"
   }
 
-  let id: String
-  let type: SchemaType
-  let target: String
+  public let id: String
+  public let type: SchemaType
+  public let target: String
 }

--- a/Tests/CoreXLSXTests/Relationships.swift
+++ b/Tests/CoreXLSXTests/Relationships.swift
@@ -56,6 +56,16 @@ final class RelationshipsTests: XCTestCase {
       let relationships = try decoder.decode(Relationships.self,
                                              from: exampleXML)
       XCTAssertEqual(relationships.items, parsed)
+
+      guard let file =
+        XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
+          XCTAssert(false, "failed to open the file")
+          return
+      }
+
+      let relationshipsFromFile = try file.parseRelationships()
+
+      XCTAssertEqual(relationshipsFromFile, Relationships(items: parsed))
     } catch {
       XCTAssert(false, "unexpected error \(error)")
     }


### PR DESCRIPTION
As reported in #19 without a `public Relationships` type `Workbook` values can't be matched to `Worksheet` cleanly. `Relationships` type already existed in the library, so it makes sense to make it `public` and to expose `public func parseRelationships` that returns a value of that type for a given `XLSXFile` instance.

Resolves #19.