### PR TITLE
Add `public func parseDocumentRelationships`

### DIFF
--- a/Sources/CoreXLSX/CoreXLSX.swift
+++ b/Sources/CoreXLSX/CoreXLSX.swift
@@ -106,10 +106,8 @@ public struct XLSXFile {
       // storing that path in `pathPrefix`
       let pathPrefix = rels.0.dropLast().joined(separator: "/")
 
-      let result: [String] = rels.1.items.filter { $0.type == .worksheet }
+      return rels.1.items.filter { $0.type == .worksheet }
         .map { "\(pathPrefix)/\($0.target)" }
-
-      return result
     }
   }
 

--- a/Sources/CoreXLSX/CoreXLSX.swift
+++ b/Sources/CoreXLSX/CoreXLSX.swift
@@ -80,25 +80,36 @@ public struct XLSXFile {
     }
   }
 
-  /// Parse and return an array of worksheets in this XLSX file.
-  public func parseWorksheetPaths() throws -> [String] {
+  /// Return pairs of parsed document paths with corresponding relationships
+  public func parseDocumentRelationships() throws
+  -> [([Substring], Relationships)] {
     decoder.keyDecodingStrategy = .convertFromCapitalized
 
-    return try parseDocumentPaths().flatMap { (path: String) -> [String] in
-      var components = path.split(separator: "/")
-
-      // .rels file has paths relative to its directory,
-      // storing that path in `pathPrefix`
-      let pathPrefix = components.dropLast().joined(separator: "/")
+    return try parseDocumentPaths().compactMap { path -> ([Substring], Relationships)? in
+      let originalComponents = path.split(separator: "/")
+      var components = originalComponents
 
       components.insert("_rels", at: 1)
-      guard let filename = components.last else { return [] }
+      guard let filename = components.last else { return nil }
       components[components.count - 1] = Substring(filename.appending(".rels"))
 
-      return
-        try parseEntry(components.joined(separator: "/"), Relationships.self)
-          .items.filter { $0.type == .worksheet }
-          .map { "\(pathPrefix)/\($0.target)" }
+      let relationships = try parseEntry(components.joined(separator: "/"),
+                                         Relationships.self)
+      return (originalComponents, relationships)
+    }
+  }
+
+  /// Parse and return an array of worksheets in this XLSX file.
+  public func parseWorksheetPaths() throws -> [String] {
+    return try parseDocumentRelationships().flatMap { rels -> [String] in
+      // .rels file has paths relative to its directory,
+      // storing that path in `pathPrefix`
+      let pathPrefix = rels.0.dropLast().joined(separator: "/")
+
+      let result: [String] = rels.1.items.filter { $0.type == .worksheet }
+        .map { "\(pathPrefix)/\($0.target)" }
+
+      return result
     }
   }
 

--- a/Sources/CoreXLSX/CoreXLSX.swift
+++ b/Sources/CoreXLSX/CoreXLSX.swift
@@ -101,12 +101,13 @@ public struct XLSXFile {
 
   /// Parse and return an array of worksheets in this XLSX file.
   public func parseWorksheetPaths() throws -> [String] {
-    return try parseDocumentRelationships().flatMap { rels -> [String] in
+    return try parseDocumentRelationships()
+    .flatMap { (pathComponents, relationships) -> [String] in
       // .rels file has paths relative to its directory,
       // storing that path in `pathPrefix`
-      let pathPrefix = rels.0.dropLast().joined(separator: "/")
+      let pathPrefix = pathComponents.dropLast().joined(separator: "/")
 
-      return rels.1.items.filter { $0.type == .worksheet }
+      return relationships.items.filter { $0.type == .worksheet }
         .map { "\(pathPrefix)/\($0.target)" }
     }
   }


### PR DESCRIPTION
A followup to #19: `XLSXFile.parseRelationships` returns only a parsed root `_rels/.rels` file, but there's no public API to get relationships for every document parsed from the root relationships file. `parseDocumentRelationships` implements that.