### PR TITLE
Fix root paths in CoreXLSX, fix formatter & linter

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,3 +17,4 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Carthage
   - .build
   - Example/Pods
+  

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,3 +12,8 @@ line_length:
 
 function_body_length:
 - 50
+
+excluded: # paths to ignore during linting. Takes precedence over `included`.
+  - Carthage
+  - .build
+  - Example/Pods

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,11 @@ before_install:
 - brew install swiftformat
 - brew outdated carthage || brew upgrade carthage
 # - pod install --project-directory=Example
-before_script:
-# bootstrap the dependencies for the project
-- carthage bootstrap
 script:
 - swiftformat --lint --verbose .
 - pod lib lint --verbose
+# bootstrap the dependencies for the project
+- carthage bootstrap
 - xcodebuild -scheme CoreXLSXiOS
 - xcodebuild -scheme CoreXLSXwatchOS
 - xcodebuild -scheme CoreXLSXtvOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,17 @@ env:
 # cache: cocoapods
 # podfile: Example/Podfile
 before_install:
-- gem install cocoapods --pre # Since Travis is not always on latest version
+- gem install cocoapods # Since Travis is not always on latest version
 - pod repo update
+- brew update
+- brew install swiftformat
 - brew outdated carthage || brew upgrade carthage
 # - pod install --project-directory=Example
 before_script:
 # bootstrap the dependencies for the project
 - carthage bootstrap
 script:
+- swiftformat --lint --verbose .
 - pod lib lint --verbose
 - xcodebuild -scheme CoreXLSXiOS
 - xcodebuild -scheme CoreXLSXwatchOS

--- a/CoreXLSX.xcodeproj/project.pbxproj
+++ b/CoreXLSX.xcodeproj/project.pbxproj
@@ -43,6 +43,10 @@
 		D1A8191221A9D4F7004FCA33 /* CellQueries.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A8191021A9D4ED004FCA33 /* CellQueries.swift */; };
 		D1A8191321A9D4F8004FCA33 /* CellQueries.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A8191021A9D4ED004FCA33 /* CellQueries.swift */; };
 		D1A8191421A9D4F8004FCA33 /* CellQueries.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A8191021A9D4ED004FCA33 /* CellQueries.swift */; };
+		D1B4F8E0221C10AC00C53C42 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B4F8DF221C10AC00C53C42 /* Path.swift */; };
+		D1B4F8E1221C10AC00C53C42 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B4F8DF221C10AC00C53C42 /* Path.swift */; };
+		D1B4F8E2221C10AC00C53C42 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B4F8DF221C10AC00C53C42 /* Path.swift */; };
+		D1B4F8E3221C10AC00C53C42 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B4F8DF221C10AC00C53C42 /* Path.swift */; };
 		D1C96B8021A806A500303975 /* Workbook.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C96B7F21A806A500303975 /* Workbook.swift */; };
 		D1C96B8321A80EC000303975 /* Workbook.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C96B8121A80E5900303975 /* Workbook.swift */; };
 		D1EB1B3421B151440043CD1E /* SharedStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EB1B3321B151440043CD1E /* SharedStrings.swift */; };
@@ -111,6 +115,7 @@
 		D1A8190821A9CB89004FCA33 /* Worksheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Worksheet.swift; sourceTree = "<group>"; };
 		D1A8190A21A9D0EF004FCA33 /* Cell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cell.swift; sourceTree = "<group>"; };
 		D1A8191021A9D4ED004FCA33 /* CellQueries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellQueries.swift; sourceTree = "<group>"; };
+		D1B4F8DF221C10AC00C53C42 /* Path.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Path.swift; sourceTree = "<group>"; };
 		D1C96B7F21A806A500303975 /* Workbook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workbook.swift; sourceTree = "<group>"; };
 		D1C96B8121A80E5900303975 /* Workbook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workbook.swift; sourceTree = "<group>"; };
 		D1EB1B3321B151440043CD1E /* SharedStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStrings.swift; sourceTree = "<group>"; };
@@ -265,6 +270,7 @@
 				OBJ_14 /* Relationships.swift */,
 				D1C96B7F21A806A500303975 /* Workbook.swift */,
 				D1FD863D21A1F09E00B7F8D6 /* SharedStrings.swift */,
+				D1B4F8DF221C10AC00C53C42 /* Path.swift */,
 			);
 			name = CoreXLSX;
 			path = Sources/CoreXLSX;
@@ -451,6 +457,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = OBJ_58 /* Build configuration list for PBXNativeTarget "CoreXLSXmacOS" */;
 			buildPhases = (
+				D1B4F8DE221C05CF00C53C42 /* ShellScript */,
 				OBJ_61 /* Sources */,
 				OBJ_67 /* Frameworks */,
 			);
@@ -599,6 +606,26 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		D1B4F8DE221C05CF00C53C42 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		D15021CD21A1CA7D00BFA4FC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -609,6 +636,7 @@
 				D15021DF21A1CB0500BFA4FC /* CellReference.swift in Sources */,
 				D1A8191221A9D4F7004FCA33 /* CellQueries.swift in Sources */,
 				D1A8190D21A9D139004FCA33 /* Cell.swift in Sources */,
+				D1B4F8E1221C10AC00C53C42 /* Path.swift in Sources */,
 				D15021E021A1CB0500BFA4FC /* ColumnReference.swift in Sources */,
 				D15021E221A1CB0500BFA4FC /* Relationships.swift in Sources */,
 				D15021E321A1CB0500BFA4FC /* Worksheet.swift in Sources */,
@@ -625,6 +653,7 @@
 				D15021FB21A1D1DB00BFA4FC /* CellReference.swift in Sources */,
 				D1A8191321A9D4F8004FCA33 /* CellQueries.swift in Sources */,
 				D1A8190E21A9D13B004FCA33 /* Cell.swift in Sources */,
+				D1B4F8E2221C10AC00C53C42 /* Path.swift in Sources */,
 				D15021FC21A1D1DB00BFA4FC /* ColumnReference.swift in Sources */,
 				D15021FE21A1D1DB00BFA4FC /* Relationships.swift in Sources */,
 				D15021FF21A1D1DB00BFA4FC /* Worksheet.swift in Sources */,
@@ -641,6 +670,7 @@
 				D150221121A1D97E00BFA4FC /* CellReference.swift in Sources */,
 				D1A8191421A9D4F8004FCA33 /* CellQueries.swift in Sources */,
 				D1A8190F21A9D13B004FCA33 /* Cell.swift in Sources */,
+				D1B4F8E3221C10AC00C53C42 /* Path.swift in Sources */,
 				D150221221A1D97E00BFA4FC /* ColumnReference.swift in Sources */,
 				D150221421A1D97E00BFA4FC /* Relationships.swift in Sources */,
 				D150221521A1D97E00BFA4FC /* Worksheet.swift in Sources */,
@@ -657,6 +687,7 @@
 				OBJ_63 /* ColumnReference.swift in Sources */,
 				D1A8191121A9D4ED004FCA33 /* CellQueries.swift in Sources */,
 				D1A8190B21A9D0EF004FCA33 /* Cell.swift in Sources */,
+				D1B4F8E0221C10AC00C53C42 /* Path.swift in Sources */,
 				OBJ_64 /* CoreXLSX.swift in Sources */,
 				OBJ_65 /* Relationships.swift in Sources */,
 				OBJ_66 /* Worksheet.swift in Sources */,

--- a/Example/CoreXLSX.xcodeproj/project.pbxproj
+++ b/Example/CoreXLSX.xcodeproj/project.pbxproj
@@ -14,9 +14,6 @@
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		72F32EB9CBAEB64081D35612 /* Pods_CoreXLSXTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BC8ED5DD7847E4B3DA64752 /* Pods_CoreXLSXTests.framework */; };
 		8BE8494931C11C209B2F3944 /* Pods_CoreXLSXExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA10B2D7BF73384FAC211C14 /* Pods_CoreXLSXExample.framework */; };
-		D19829712197596A00C6A761 /* CoreXLSXTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D198296B2197595F00C6A761 /* CoreXLSXTests.swift */; };
-		D1C96B7C21A7F46D00303975 /* CellReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C96B7721A7F46400303975 /* CellReferenceTests.swift */; };
-		D1C96B7D21A7F46D00303975 /* RelationshipsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C96B7621A7F46400303975 /* RelationshipsTests.swift */; };
 		D1C96B7E21A7F46D00303975 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D198296C2197595F00C6A761 /* XCTestManifests.swift */; };
 /* End PBXBuildFile section */
 
@@ -47,12 +44,9 @@
 		999E62C771CA59BF3E1DF2A6 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		CA005AF46AE2EF05BA10BB0B /* Pods-CoreXLSXTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoreXLSXTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CoreXLSXTests/Pods-CoreXLSXTests.release.xcconfig"; sourceTree = "<group>"; };
 		CA820D499A2925968F8F779B /* Pods-CoreXLSXExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoreXLSXExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-CoreXLSXExample/Pods-CoreXLSXExample.release.xcconfig"; sourceTree = "<group>"; };
-		D198296B2197595F00C6A761 /* CoreXLSXTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreXLSXTests.swift; sourceTree = "<group>"; };
 		D198296C2197595F00C6A761 /* XCTestManifests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
 		D198296D2197595F00C6A761 /* categories.xlsx */ = {isa = PBXFileReference; lastKnownFileType = file; path = categories.xlsx; sourceTree = "<group>"; };
 		D1BCEBD521944FA6000B550F /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Package.swift; path = ../Package.swift; sourceTree = "<group>"; };
-		D1C96B7621A7F46400303975 /* RelationshipsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelationshipsTests.swift; sourceTree = "<group>"; };
-		D1C96B7721A7F46400303975 /* CellReferenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CellReferenceTests.swift; sourceTree = "<group>"; };
 		DA10B2D7BF73384FAC211C14 /* Pods_CoreXLSXExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CoreXLSXExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE826BAD89D91945EB1EAE81 /* CoreXLSX.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = CoreXLSX.podspec; path = ../CoreXLSX.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 /* End PBXFileReference section */
@@ -173,9 +167,6 @@
 		D198296A2197595F00C6A761 /* CoreXLSXTests */ = {
 			isa = PBXGroup;
 			children = (
-				D1C96B7721A7F46400303975 /* CellReferenceTests.swift */,
-				D1C96B7621A7F46400303975 /* RelationshipsTests.swift */,
-				D198296B2197595F00C6A761 /* CoreXLSXTests.swift */,
 				D198296C2197595F00C6A761 /* XCTestManifests.swift */,
 				D198296D2197595F00C6A761 /* categories.xlsx */,
 			);
@@ -359,10 +350,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D19829712197596A00C6A761 /* CoreXLSXTests.swift in Sources */,
 				D1C96B7E21A7F46D00303975 /* XCTestManifests.swift in Sources */,
-				D1C96B7C21A7F46D00303975 /* CellReferenceTests.swift in Sources */,
-				D1C96B7D21A7F46D00303975 /* RelationshipsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/CoreXLSXExample/AppDelegate.swift
+++ b/Example/CoreXLSXExample/AppDelegate.swift
@@ -10,37 +10,48 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
 
-    var window: UIWindow?
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions options: [UIApplicationLaunchOptionsKey: Any]?
+  ) -> Bool {
+    // Override point for customization after application launch.
+    return true
+  }
 
+  func applicationWillResignActive(_ application: UIApplication) {
+    // Sent when the application is about to move from active to inactive state.
+    // This can occur for certain types of temporary interruptions (such as an
+    // incoming phone call or SMS message) or when the user quits the
+    // application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle
+    // down OpenGL ES frame rates. Games should use this method to pause the
+    // game.
+  }
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
-        return true
-    }
+  func applicationDidEnterBackground(_ application: UIApplication) {
+    // Use this method to release shared resources, save user data, invalidate
+    // timers, and store enough application state information to restore your
+    // application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called
+    // instead of applicationWillTerminate: when the user quits.
+  }
 
-    func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
-    }
+  func applicationWillEnterForeground(_ application: UIApplication) {
+    // Called as part of the transition from the background to the inactive
+    // state; here you can undo many of the changes made on entering the
+    // background.
+  }
 
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
+  func applicationDidBecomeActive(_ application: UIApplication) {
+    // Restart any tasks that were paused (or not yet started) while the
+    // application was inactive. If the application was previously in the
+    // background, optionally refresh the user interface.
+  }
 
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-
-
+  func applicationWillTerminate(_ application: UIApplication) {
+    // Called when the application is about to terminate. Save data if
+    // appropriate. See also applicationDidEnterBackground:.
+  }
 }
-

--- a/Example/CoreXLSXExample/ViewController.swift
+++ b/Example/CoreXLSXExample/ViewController.swift
@@ -6,20 +6,17 @@
 //  Copyright (c) 2018 Max Desiatov. All rights reserved.
 //
 
-import UIKit
 import CoreXLSX
+import UIKit
 
 class ViewController: UIViewController {
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    // Do any additional setup after loading the view, typically from a nib.
+  }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        // Do any additional setup after loading the view, typically from a nib.
-    }
-
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
-    }
-
+  override func didReceiveMemoryWarning() {
+    super.didReceiveMemoryWarning()
+    // Dispose of any resources that can be recreated.
+  }
 }
-

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - CoreXLSX (0.1.0):
-    - XMLCoder (~> 0.1)
-    - ZIPFoundation (~> 0.9)
-  - XMLCoder (0.1.0)
-  - ZIPFoundation (0.9.6)
+  - CoreXLSX (0.4.0):
+    - XMLCoder (~> 0.3.1)
+    - ZIPFoundation (~> 0.9.8)
+  - XMLCoder (0.3.1)
+  - ZIPFoundation (0.9.8)
 
 DEPENDENCIES:
   - CoreXLSX (from `../`)
@@ -18,10 +18,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CoreXLSX: fcc57ac942fb842968a346587d51a1680f27c09d
-  XMLCoder: af0b69d184654d8f58a4bc4168d20ee95b7e8203
-  ZIPFoundation: 68c35eb2637c21abe56dc60b3277636443bc1501
+  CoreXLSX: f66830376a1dee431eacef84508edd414085b515
+  XMLCoder: 449e4e90d6c7641ea2445f1b2c791fab72cdb18c
+  ZIPFoundation: b1f07e4409baf1641f3fe5948b2a1c3f5c500cb1
 
 PODFILE CHECKSUM: 4b59cda9563eaa9d39027ba3749963cf8b4676e7
 
-COCOAPODS: 1.6.0.beta.2
+COCOAPODS: 1.6.0

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,8 @@ let package = Package(
     // and make them visible to other packages.
     .library(
       name: "CoreXLSX",
-      targets: ["CoreXLSX"]),
+      targets: ["CoreXLSX"]
+    ),
   ],
   dependencies: [
     // Dependencies declare other packages that this package depends on.
@@ -28,9 +29,11 @@ let package = Package(
     // packages which this package depends on.
     .target(
       name: "CoreXLSX",
-      dependencies: ["XMLCoder", "ZIPFoundation"]),
+      dependencies: ["XMLCoder", "ZIPFoundation"]
+    ),
     .testTarget(
       name: "CoreXLSXTests",
-      dependencies: ["CoreXLSX"]),
+      dependencies: ["CoreXLSX"]
+    ),
   ]
 )

--- a/Sources/CoreXLSX/CoreXLSX.swift
+++ b/Sources/CoreXLSX/CoreXLSX.swift
@@ -58,7 +58,10 @@ public struct XLSXFile {
 
   /// Parse a file within `archive` at `path`. Parsing result is
   /// an instance of `type`.
-  func parseEntry<T: Decodable>(_ pathString: String, _ type: T.Type) throws -> T {
+  func parseEntry<T: Decodable>(
+    _ pathString: String,
+    _ type: T.Type
+  ) throws -> T {
     let path = Path(pathString)
     let entryPath = path.isRoot ?
       path.components.joined(separator: "/") :

--- a/Sources/CoreXLSX/CoreXLSX.swift
+++ b/Sources/CoreXLSX/CoreXLSX.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import ZIPFoundation
 import XMLCoder
+import ZIPFoundation
 
 @available(*, deprecated, renamed: "CoreXLSXError")
 public typealias XLSXReaderError = CoreXLSXError
@@ -27,8 +27,8 @@ public struct XLSXFile {
 
   /// - Parameters:
   ///   - filepath: path to the `.xlsx` file to be processed.
-  ///   - bufferSize: ZIP archive buffer size in bytes. The default is 10KB. You 
-  /// may need to set a bigger buffer size for bigger files.
+  ///   - bufferSize: ZIP archive buffer size in bytes. The default is 10KB.
+  /// You may need to set a bigger buffer size for bigger files.
   ///   - errorContextLength: The error context length. The default is `0`.
   /// Non-zero length makes an error thrown from
   /// the XML parser with line/column location repackaged with a context
@@ -58,8 +58,13 @@ public struct XLSXFile {
 
   /// Parse a file within `archive` at `path`. Parsing result is
   /// an instance of `type`.
-  func parseEntry<T: Decodable>(_ path: String, _ type: T.Type) throws -> T {
-    guard let entry = archive[path] else {
+  func parseEntry<T: Decodable>(_ pathString: String, _ type: T.Type) throws -> T {
+    let path = Path(pathString)
+    let entryPath = path.isRoot ?
+      path.components.joined(separator: "/") :
+      pathString
+
+    guard let entry = archive[entryPath] else {
       throw CoreXLSXError.archiveEntryNotFound
     }
 
@@ -97,39 +102,75 @@ public struct XLSXFile {
     decoder.keyDecodingStrategy = .useDefaultKeys
 
     return try paths.map {
-      return try parseEntry($0, Workbook.self)
+      try parseEntry($0, Workbook.self)
     }
   }
 
-  /// Return pairs of parsed document paths with corresponding relationships
+  /** Return pairs of parsed document paths with corresponding relationships.
+
+   **Deprecation warning**: this function doesn't handle root paths correctly,
+   even though some XLSX files do contain root paths instead of relative
+   paths. Use `parseDocumentRelationships(path:)` instead.
+   */
+  @available(*, deprecated, renamed: "parseDocumentRelationships(path:)")
   public func parseDocumentRelationships() throws
-  -> [([Substring], Relationships)] {
+    -> [([Substring], Relationships)] {
     decoder.keyDecodingStrategy = .convertFromCapitalized
 
-    return try parseDocumentPaths().compactMap { path -> ([Substring], Relationships)? in
-      let originalComponents = path.split(separator: "/")
-      var components = originalComponents
+    return try parseDocumentPaths()
+      .compactMap { path -> ([Substring], Relationships)? in
+        let originalComponents = path.split(separator: "/")
+        var components = originalComponents
 
-      components.insert("_rels", at: 1)
-      guard let filename = components.last else { return nil }
-      components[components.count - 1] = Substring(filename.appending(".rels"))
+        components.insert("_rels", at: 1)
+        guard let filename = components.last else { return nil }
+        components[components.count - 1] =
+          Substring(filename.appending(".rels"))
 
-      let relationships = try parseEntry(components.joined(separator: "/"),
-                                         Relationships.self)
-      return (originalComponents, relationships)
-    }
+        let relationships = try parseEntry(
+          components.joined(separator: "/"),
+          Relationships.self
+        )
+        return (originalComponents, relationships)
+      }
+  }
+
+  /// Return parsed path with a parsed relationships model for a document at
+  /// given path. Use `parseDocumentPaths` first to get a string path to pass
+  /// as an argument to this function.
+  public func parseDocumentRelationships(path: String) throws
+    -> (Path, Relationships) {
+    decoder.keyDecodingStrategy = .convertFromCapitalized
+
+    let originalPath = Path(path)
+    var components = originalPath.components
+
+    components.insert("_rels", at: 1)
+    guard let filename = components.last else { fatalError() }
+    components[components.count - 1] =
+      Substring(filename.appending(".rels"))
+
+    let relationships = try parseEntry(
+      components.joined(separator: "/"),
+      Relationships.self
+    )
+    return (originalPath, relationships)
   }
 
   /// Parse and return an array of worksheets in this XLSX file.
   public func parseWorksheetPaths() throws -> [String] {
-    return try parseDocumentRelationships()
-    .flatMap { (pathComponents, relationships) -> [String] in
+    return try parseDocumentPaths().map {
+      try parseDocumentRelationships(path: $0)
+    }.flatMap { (path, relationships) -> [String] in
+      let worksheets = relationships.items.filter { $0.type == .worksheet }
+
+      guard !path.isRoot else { return worksheets.map { $0.target } }
+
       // .rels file has paths relative to its directory,
       // storing that path in `pathPrefix`
-      let pathPrefix = pathComponents.dropLast().joined(separator: "/")
+      let pathPrefix = path.components.dropLast().joined(separator: "/")
 
-      return relationships.items.filter { $0.type == .worksheet }
-        .map { "\(pathPrefix)/\($0.target)" }
+      return worksheets.map { "\(pathPrefix)/\($0.target)" }
     }
   }
 
@@ -143,7 +184,7 @@ public struct XLSXFile {
   /// Return all cells that are contained in a given worksheet and set of rows.
   @available(*, deprecated, renamed: "Worksheet.cells(atRows:)")
   public func cellsInWorksheet(at path: String, rows: [Int]) throws
-  -> [Cell] {
+    -> [Cell] {
     let ws = try parseWorksheet(at: path)
 
     return ws.data?.rows.filter { rows.contains(Int($0.reference)) }
@@ -156,16 +197,16 @@ public struct XLSXFile {
   /// of `String`s.
   @available(*, deprecated, renamed: "Worksheet.cells(atColumns:)")
   public func cellsInWorksheet(at path: String, columns: [String]) throws
-  -> [Cell] {
+    -> [Cell] {
     let ws = try parseWorksheet(at: path)
 
     return ws.data?.rows.map {
       let rowReference = $0.reference
-      let targetReferences = columns.compactMap {
-      (c: String) -> CellReference? in
-        guard let columnReference = ColumnReference(c) else { return nil }
-        return CellReference(columnReference, rowReference)
-      }
+      let targetReferences = columns
+        .compactMap { (c: String) -> CellReference? in
+          guard let columnReference = ColumnReference(c) else { return nil }
+          return CellReference(columnReference, rowReference)
+        }
       return $0.cells.filter { targetReferences.contains($0.reference) }
     }
     .reduce([]) { $0 + $1 } ?? []

--- a/Sources/CoreXLSX/Path.swift
+++ b/Sources/CoreXLSX/Path.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  CoreXLSX
+//
+//  Created by Max Desiatov on 19/02/2019.
+//
+
+public struct Path {
+  public let value: String
+  public let isRoot: Bool
+  public let components: [Substring]
+
+  public init(_ value: String) {
+    self.value = value
+    isRoot = value.first == "/"
+    components = value.split(separator: "/")
+  }
+}

--- a/Sources/CoreXLSX/Relationships.swift
+++ b/Sources/CoreXLSX/Relationships.swift
@@ -15,17 +15,53 @@ public struct Relationships: Codable, Equatable {
 
 public struct Relationship: Codable, Equatable {
   public enum SchemaType: String, Codable {
-    case calcChain = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/calcChain"
-    case officeDocument = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
-    case extendedProperties = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties"
-    case coreProperties = "http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties"
-    case worksheet = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"
-    case sharedStrings = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"
-    case styles = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"
-    case theme = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme"
-    case pivotCache = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition"
-    case metadataThumbnail = "http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail"
-    case customProperties = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties"
+    case calcChain =
+      """
+      http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
+      calcChain
+      """
+    case officeDocument =
+      """
+      http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
+      officeDocument
+      """
+    case extendedProperties =
+      """
+      http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
+      extended-properties
+      """
+    case coreProperties = """
+    http://schemas.openxmlformats.org/package/2006/relationships/metadata/\
+    core-properties
+    """
+    case worksheet = """
+    http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
+    worksheet
+    """
+    case sharedStrings = """
+    http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
+    sharedStrings
+    """
+    case styles = """
+    http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
+    styles
+    """
+    case theme = """
+    http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
+    theme
+    """
+    case pivotCache = """
+    http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
+    pivotCacheDefinition
+    """
+    case metadataThumbnail = """
+    http://schemas.openxmlformats.org/package/2006/relationships/metadata/\
+    thumbnail
+    """
+    case customProperties = """
+    http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
+    custom-properties
+    """
   }
 
   public let id: String

--- a/Sources/CoreXLSX/Workbook.swift
+++ b/Sources/CoreXLSX/Workbook.swift
@@ -37,7 +37,7 @@ public struct Workbook: Codable, Equatable {
     public let relationship: String
 
     enum CodingKeys: String, CodingKey {
-      case name = "name"
+      case name
       case id = "sheetId"
       case relationship = "r:id"
     }

--- a/Sources/CoreXLSX/Worksheet/Cell.swift
+++ b/Sources/CoreXLSX/Worksheet/Cell.swift
@@ -9,10 +9,10 @@ public struct Cell: Codable, Equatable {
   public let reference: CellReference
   public let type: String?
 
-  /// FIXME: Attribute "s" in a cell is an index into the styles table,
-  /// while the cell type "s" corresponds to the shared string table.
-  /// Can XMLCoder distinguish between an attribute and an
-  /// element having the same name?
+  // FIXME: Attribute "s" in a cell is an index into the styles table,
+  // while the cell type "s" corresponds to the shared string table.
+  // Can XMLCoder distinguish between an attribute and an
+  // element having the same name?
   public let s: String?
   public let inlineString: InlineString?
   public let formula: String?

--- a/Sources/CoreXLSX/Worksheet/CellQueries.swift
+++ b/Sources/CoreXLSX/Worksheet/CellQueries.swift
@@ -10,18 +10,18 @@ extension Worksheet {
   /// columns.
   public func cells<T>(atColumns columns: T) -> [Cell]
     where T: Collection, T.Element == ColumnReference {
-      return data?.rows.map {
-        return $0.cells.filter { columns.contains($0.reference.column) }
-        }
-        .reduce([]) { $0 + $1 } ?? []
+    return data?.rows.map {
+      $0.cells.filter { columns.contains($0.reference.column) }
+    }
+    .reduce([]) { $0 + $1 } ?? []
   }
 
   /// Return all cells that are contained in a given worksheet and collection of
   /// rows.
   public func cells<T>(atRows rows: T) -> [Cell]
     where T: Collection, T.Element == UInt {
-      return data?.rows.filter { rows.contains($0.reference) }
-        .reduce([]) { $0 + $1.cells } ?? []
+    return data?.rows.filter { rows.contains($0.reference) }
+      .reduce([]) { $0 + $1.cells } ?? []
   }
 
   /// Return all cells that are contained in a given worksheet and collections
@@ -29,9 +29,9 @@ extension Worksheet {
   public func cells<T1, T2>(atColumns columns: T1, rows: T2) -> [Cell]
     where T1: Collection, T1.Element == ColumnReference,
     T2: Collection, T2.Element == UInt {
-      return data?.rows.filter { rows.contains($0.reference) }.map {
-        return $0.cells.filter { columns.contains($0.reference.column) }
-        }
-        .reduce([]) { $0 + $1 } ?? []
+    return data?.rows.filter { rows.contains($0.reference) }.map {
+      $0.cells.filter { columns.contains($0.reference.column) }
+    }
+    .reduce([]) { $0 + $1 } ?? []
   }
 }

--- a/Sources/CoreXLSX/Worksheet/CellReference.swift
+++ b/Sources/CoreXLSX/Worksheet/CellReference.swift
@@ -18,7 +18,7 @@ public struct CellReference {
 }
 
 extension CellReference: Equatable {
-  public static func == (lhs: CellReference, rhs: CellReference) -> Bool {
+  public static func ==(lhs: CellReference, rhs: CellReference) -> Bool {
     return lhs.column == rhs.column && lhs.row == rhs.row
   }
 }
@@ -37,7 +37,6 @@ extension CellReference: Decodable {
     guard let lastLetterIndex = reference.lastIndex(where: {
       $0.unicodeScalars.allSatisfy {
         ColumnReference.allowedCharacters.contains($0)
-
       }
     }) else {
       throw CoreXLSXError.invalidCellReference
@@ -46,7 +45,7 @@ extension CellReference: Decodable {
     let separatorIndex = reference.index(after: lastLetterIndex)
 
     guard let column =
-    ColumnReference(reference.prefix(upTo: separatorIndex)) else {
+      ColumnReference(reference.prefix(upTo: separatorIndex)) else {
       throw CoreXLSXError.invalidCellReference
     }
 

--- a/Sources/CoreXLSX/Worksheet/ColumnReference.swift
+++ b/Sources/CoreXLSX/Worksheet/ColumnReference.swift
@@ -19,7 +19,7 @@ public struct ColumnReference {
 
     // log(1) == 0, working around that
     let symbolsCount = value == 1 ? 1 : Int(ceil(log(Double(value)) /
-      log(Double(ColumnReference.alphabetLength))))
+        log(Double(ColumnReference.alphabetLength))))
 
     var power = 1
     var value = value
@@ -40,7 +40,9 @@ public struct ColumnReference {
     }
 
     func reducer(acc: String, i: Int) -> String {
-      return String(Character(UnicodeScalar(ColumnReference.firstAllowedCharacter.value - 1 + UInt32(i))!)) + acc
+      return String(Character(UnicodeScalar(
+        ColumnReference.firstAllowedCharacter.value - 1 + UInt32(i)
+      )!)) + acc
     }
 
     let result = (0..<symbolsCount).compactMap(symbolValue).reduce("", reducer)
@@ -74,7 +76,7 @@ public struct ColumnReference {
     // from a previous iteration
     var power = 1
 
-    self.intValue = (0..<count).map {
+    intValue = (0..<count).map {
       // integer value for a symbol at a given position
       let symbolValue = Int(scalars[count - $0 - 1].value -
         ColumnReference.firstAllowedCharacter.value + 1)
@@ -105,11 +107,11 @@ extension ColumnReference: CustomStringConvertible {
 }
 
 extension ColumnReference: Comparable {
-  public static func < (lhs: ColumnReference, rhs: ColumnReference) -> Bool {
+  public static func <(lhs: ColumnReference, rhs: ColumnReference) -> Bool {
     return lhs.value < rhs.value
   }
 
-  public static func == (lhs: ColumnReference, rhs: ColumnReference) -> Bool {
+  public static func ==(lhs: ColumnReference, rhs: ColumnReference) -> Bool {
     return lhs.value == rhs.value
   }
 }

--- a/Sources/CoreXLSX/Worksheet/Worksheet.swift
+++ b/Sources/CoreXLSX/Worksheet/Worksheet.swift
@@ -42,7 +42,7 @@ public struct Worksheet: Codable {
 
     public let defaultColumnWidth: String?
 
-    public let defaultRowHeight: String
+    public let defaultRowHeight: String?
     public let customHeight: String?
     public let outlineLevelRow: String?
 
@@ -59,6 +59,20 @@ public struct Worksheet: Codable {
       case customHeight
       case outlineLevelRow
       case outlineLevelColumn = "outlineLevelCol"
+    }
+
+    init(
+      defaultColumnWidth: String? = nil,
+      defaultRowHeight: String? = nil,
+      customHeight: String? = nil,
+      outlineLevelRow: String? = nil,
+      outlineLevelColumn: String? = nil
+    ) {
+      self.defaultColumnWidth = defaultColumnWidth
+      self.defaultRowHeight = defaultRowHeight
+      self.customHeight = customHeight
+      self.outlineLevelRow = outlineLevelRow
+      self.outlineLevelColumn = outlineLevelColumn
     }
   }
 
@@ -82,17 +96,18 @@ public struct Worksheet: Codable {
     }
   }
 
+  // swiftlint:disable next line_length
   /// https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.sheetdimension?view=openxml-2.8.1
   public let dimension: Dimension?
 
-  public let sheetViews: SheetViews
+  public let sheetViews: SheetViews?
 
   @available(*, deprecated, renamed: "formatProperties")
   public var sheetFormatPr: SheetFormatPr {
-    return formatProperties
+    return formatProperties ?? FormatProperties()
   }
 
-  public let formatProperties: FormatProperties
+  public let formatProperties: FormatProperties?
   public let columns: Columns?
 
   @available(*, deprecated, renamed: "columns")

--- a/Tests/CoreXLSXTests/CellReference.swift
+++ b/Tests/CoreXLSXTests/CellReference.swift
@@ -25,44 +25,39 @@ final class CellReferenceTests: XCTestCase {
   private let decoder = XMLDecoder()
   private let encoder = XMLEncoder()
 
-  func testCellReference() {
-    do {
-      let c1 = try decoder.decode(Cell.self, from: exampleXML1)
-      let cr1 = CellReference(ColumnReference("A")!, 7)
-      XCTAssertEqual(cr1.description, "A7")
-      XCTAssertEqual(
-        c1,
-        Cell(
-          reference: cr1,
-          type: nil, s: nil, inlineString: nil, formula: nil,
-          value: nil
-        )
+  func testCellReference() throws {
+    let c1 = try decoder.decode(Cell.self, from: exampleXML1)
+    let cr1 = CellReference(ColumnReference("A")!, 7)
+    XCTAssertEqual(cr1.description, "A7")
+    XCTAssertEqual(
+      c1,
+      Cell(
+        reference: cr1,
+        type: nil, s: nil, inlineString: nil, formula: nil,
+        value: nil
       )
+    )
 
-      let c2 = try decoder.decode(Cell.self, from: exampleXML2)
-      let cr2 = CellReference(ColumnReference("ZA")!, 47)
+    let c2 = try decoder.decode(Cell.self, from: exampleXML2)
+    let cr2 = CellReference(ColumnReference("ZA")!, 47)
 
-      XCTAssertThrowsError(try decoder.decode(Cell.self, from: exampleXML3))
+    XCTAssertThrowsError(try decoder.decode(Cell.self, from: exampleXML3))
 
-      XCTAssertEqual(cr2.description, "ZA47")
-      XCTAssertEqual(
-        c2,
-        Cell(
-          reference: cr2,
-          type: nil, s: nil, inlineString: nil, formula: nil,
-          value: nil
-        )
+    XCTAssertEqual(cr2.description, "ZA47")
+    XCTAssertEqual(
+      c2,
+      Cell(
+        reference: cr2,
+        type: nil, s: nil, inlineString: nil, formula: nil,
+        value: nil
       )
+    )
 
-      let c1Encoded = try encoder.encode(c1, withRootKey: "Cell")
-      XCTAssertEqual(c1, try decoder.decode(Cell.self, from: c1Encoded))
+    let c1Encoded = try encoder.encode(c1, withRootKey: "Cell")
+    XCTAssertEqual(c1, try decoder.decode(Cell.self, from: c1Encoded))
 
-      let c2Encoded = try encoder.encode(c2, withRootKey: "Cell")
-      XCTAssertEqual(c2, try decoder.decode(Cell.self, from: c2Encoded))
-
-    } catch {
-      XCTAssert(false, "unexpected error \(error)")
-    }
+    let c2Encoded = try encoder.encode(c2, withRootKey: "Cell")
+    XCTAssertEqual(c2, try decoder.decode(Cell.self, from: c2Encoded))
   }
 
   func testColumnReference() {

--- a/Tests/CoreXLSXTests/CellReference.swift
+++ b/Tests/CoreXLSXTests/CellReference.swift
@@ -5,9 +5,9 @@
 //  Created by Max Desiatov on 15/11/2018.
 //
 
+@testable import CoreXLSX
 import XCTest
 import XMLCoder
-@testable import CoreXLSX
 
 private let exampleXML1 = """
 <Cell r="A7" />
@@ -21,7 +21,6 @@ private let exampleXML3 = """
 <Cell r="kljsndfkvljdsfnjkvl" />
 """.data(using: .utf8)!
 
-
 final class CellReferenceTests: XCTestCase {
   private let decoder = XMLDecoder()
   private let encoder = XMLEncoder()
@@ -31,10 +30,14 @@ final class CellReferenceTests: XCTestCase {
       let c1 = try decoder.decode(Cell.self, from: exampleXML1)
       let cr1 = CellReference(ColumnReference("A")!, 7)
       XCTAssertEqual(cr1.description, "A7")
-      XCTAssertEqual(c1,
-                     Cell(reference: cr1,
-                          type: nil, s: nil, inlineString: nil, formula: nil,
-                          value: nil))
+      XCTAssertEqual(
+        c1,
+        Cell(
+          reference: cr1,
+          type: nil, s: nil, inlineString: nil, formula: nil,
+          value: nil
+        )
+      )
 
       let c2 = try decoder.decode(Cell.self, from: exampleXML2)
       let cr2 = CellReference(ColumnReference("ZA")!, 47)
@@ -42,10 +45,14 @@ final class CellReferenceTests: XCTestCase {
       XCTAssertThrowsError(try decoder.decode(Cell.self, from: exampleXML3))
 
       XCTAssertEqual(cr2.description, "ZA47")
-      XCTAssertEqual(c2,
-                     Cell(reference: cr2,
-                     type: nil, s: nil, inlineString: nil, formula: nil,
-                     value: nil))
+      XCTAssertEqual(
+        c2,
+        Cell(
+          reference: cr2,
+          type: nil, s: nil, inlineString: nil, formula: nil,
+          value: nil
+        )
+      )
 
       let c1Encoded = try encoder.encode(c1, withRootKey: "Cell")
       XCTAssertEqual(c1, try decoder.decode(Cell.self, from: c1Encoded))
@@ -77,8 +84,8 @@ final class CellReferenceTests: XCTestCase {
 
   func testColumnReferenceDistance() {
     guard let a = ColumnReference("A"), let z = ColumnReference("z"),
-    let aa = ColumnReference("AA"), let az = ColumnReference("Az"),
-    let ba = ColumnReference("ba"), let bz = ColumnReference("bz") else {
+      let aa = ColumnReference("AA"), let az = ColumnReference("Az"),
+      let ba = ColumnReference("ba"), let bz = ColumnReference("bz") else {
       XCTAssert(false, "failed to create simple column references")
       return
     }
@@ -102,8 +109,8 @@ final class CellReferenceTests: XCTestCase {
       let ba = ColumnReference("ba"), let bz = ColumnReference("bz"),
       let abc = ColumnReference("abc"), let azz = ColumnReference("azz"),
       let zz = ColumnReference("zz"), let azza = ColumnReference("azza") else {
-        XCTAssert(false, "failed to create simple column references")
-        return
+      XCTAssert(false, "failed to create simple column references")
+      return
     }
 
     XCTAssertEqual(ColumnReference(a.intValue), a)
@@ -120,7 +127,7 @@ final class CellReferenceTests: XCTestCase {
 
   func testColumnReferenceStringInitializerPerformance() {
     measure {
-      for _ in 0..<10_000 {
+      for _ in 0..<10000 {
         _ = ColumnReference("kjhbjhblkjn")
       }
     }
@@ -128,7 +135,7 @@ final class CellReferenceTests: XCTestCase {
 
   func testColumnReferenceIntInitializerPerformance() {
     measure {
-      for _ in 0..<10_000 {
+      for _ in 0..<10000 {
         _ = ColumnReference(Int.max / 10)
       }
     }
@@ -148,6 +155,6 @@ final class CellReferenceTests: XCTestCase {
     ("testCellReference", testCellReference),
     ("testColumnReferenceDistance", testColumnReferenceDistance),
     ("testColumnReferenceStringInitializerPerformance",
-       testColumnReferenceStringInitializerPerformance)
+     testColumnReferenceStringInitializerPerformance),
   ]
 }

--- a/Tests/CoreXLSXTests/CoreXLSX.swift
+++ b/Tests/CoreXLSXTests/CoreXLSX.swift
@@ -5,8 +5,8 @@
 //  Created by Max Desiatov on 27/10/2018.
 //
 
-import XCTest
 @testable import CoreXLSX
+import XCTest
 
 let currentWorkingPath = ProcessInfo.processInfo.environment["TESTS_PATH"]!
 
@@ -17,8 +17,8 @@ final class CoreXLSXTests: XCTestCase {
     do {
       guard let file =
         XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
-          XCTAssert(false, "failed to open the file")
-          return
+        XCTAssert(false, "failed to open the file")
+        return
       }
 
       XCTAssertEqual(try file.parseDocumentPaths(), ["xl/workbook.xml"])
@@ -64,7 +64,7 @@ final class CoreXLSXTests: XCTestCase {
   func testLegacyPublicAPI() {
     do {
       guard let file =
-      XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
+        XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
         XCTAssert(false, "failed to open the file")
         return
       }
@@ -76,8 +76,14 @@ final class CoreXLSXTests: XCTestCase {
       XCTAssertEqual(ws.cols, ws.columns)
       XCTAssertEqual(ws.sheetPr, ws.properties)
       XCTAssertEqual(ws.sheetFormatPr, ws.formatProperties)
-      XCTAssertEqual(ws.sheetFormatPr.defaultColWidth, ws.formatProperties.defaultColumnWidth)
-      XCTAssertEqual(ws.sheetFormatPr.outlineLevelCol, ws.formatProperties.outlineLevelColumn)
+      XCTAssertEqual(
+        ws.sheetFormatPr.defaultColWidth,
+        ws.formatProperties?.defaultColumnWidth
+      )
+      XCTAssertEqual(
+        ws.sheetFormatPr.outlineLevelCol,
+        ws.formatProperties?.outlineLevelColumn
+      )
       XCTAssertEqual(ws.dimension?.ref, ws.dimension?.reference)
 
       guard let mcs = ws.mergeCells else {

--- a/Tests/CoreXLSXTests/CoreXLSX.swift
+++ b/Tests/CoreXLSXTests/CoreXLSX.swift
@@ -13,114 +13,109 @@ let currentWorkingPath = ProcessInfo.processInfo.environment["TESTS_PATH"]!
 final class CoreXLSXTests: XCTestCase {
   private let sheetPath = "xl/worksheets/sheet1.xml"
 
-  func testPublicAPI() {
-    do {
-      guard let file =
-        XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
-        XCTAssert(false, "failed to open the file")
-        return
-      }
-
-      XCTAssertEqual(try file.parseDocumentPaths(), ["xl/workbook.xml"])
-      XCTAssertEqual(try file.parseWorksheetPaths(), [sheetPath])
-
-      let ws = try file.parseWorksheet(at: sheetPath)
-      guard let sd = ws.data else {
-        XCTAssert(false, "no sheet data available")
-        return
-      }
-      let allCells = sd.rows
-        .map { $0.cells }
-        .reduce([], { $0 + $1 })
-      XCTAssertEqual(allCells.count, 90)
-
-      let rowReferences = sd.rows.map { $0.reference }
-      let cellsFromRows = ws.cells(atRows: rowReferences)
-      XCTAssertEqual(allCells, cellsFromRows)
-
-      let cellsInFirstRow = ws.cells(atRows: [1])
-      XCTAssertEqual(cellsInFirstRow.count, 6)
-
-      let firstColumn = ("A" as UnicodeScalar).value
-      let lastColumn = ("F" as UnicodeScalar).value
-      let columnReferences = (firstColumn...lastColumn)
-        .compactMap { UnicodeScalar($0) }
-        .compactMap { ColumnReference(String($0)) }
-
-      XCTAssertEqual(allCells, ws.cells(atColumns: columnReferences))
-
-      let closedRange1 = ColumnReference("A")!...ColumnReference("F")!
-      XCTAssertEqual(allCells, ws.cells(atColumns: closedRange1))
-
-      let closedRange2 = ColumnReference("A")!...ColumnReference("C")!
-      let rowsRange: ClosedRange<UInt> = 3...10
-      let cellsInRange = ws.cells(atColumns: closedRange2, rows: rowsRange)
-      XCTAssertEqual(cellsInRange.count, closedRange2.count * rowsRange.count)
-    } catch {
-      XCTAssert(false, "unexpected error \(error)")
+  func testPublicAPI() throws {
+    guard let file =
+      XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
+      XCTAssert(false, "failed to open the file")
+      return
     }
+
+    XCTAssertEqual(try file.parseDocumentPaths(), ["xl/workbook.xml"])
+    XCTAssertEqual(try file.parseWorksheetPaths(), [sheetPath])
+
+    let ws = try file.parseWorksheet(at: sheetPath)
+    guard let sd = ws.data else {
+      XCTAssert(false, "no sheet data available")
+      return
+    }
+    let allCells = sd.rows
+      .map { $0.cells }
+      .reduce([], { $0 + $1 })
+    XCTAssertEqual(allCells.count, 90)
+
+    let rowReferences = sd.rows.map { $0.reference }
+    let cellsFromRows = ws.cells(atRows: rowReferences)
+    XCTAssertEqual(allCells, cellsFromRows)
+
+    let cellsInFirstRow = ws.cells(atRows: [1])
+    XCTAssertEqual(cellsInFirstRow.count, 6)
+
+    let firstColumn = ("A" as UnicodeScalar).value
+    let lastColumn = ("F" as UnicodeScalar).value
+    let columnReferences = (firstColumn...lastColumn)
+      .compactMap { UnicodeScalar($0) }
+      .compactMap { ColumnReference(String($0)) }
+
+    XCTAssertEqual(allCells, ws.cells(atColumns: columnReferences))
+
+    let closedRange1 = ColumnReference("A")!...ColumnReference("F")!
+    XCTAssertEqual(allCells, ws.cells(atColumns: closedRange1))
+
+    let closedRange2 = ColumnReference("A")!...ColumnReference("C")!
+    let rowsRange: ClosedRange<UInt> = 3...10
+    let cellsInRange = ws.cells(atColumns: closedRange2, rows: rowsRange)
+    XCTAssertEqual(cellsInRange.count, closedRange2.count * rowsRange.count)
   }
 
-  func testLegacyPublicAPI() {
-    do {
-      guard let file =
-        XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
-        XCTAssert(false, "failed to open the file")
-        return
-      }
-
-      XCTAssertEqual(try file.parseDocumentPaths(), ["xl/workbook.xml"])
-      XCTAssertEqual(try file.parseWorksheetPaths(), [sheetPath])
-
-      let ws = try file.parseWorksheet(at: sheetPath)
-      XCTAssertEqual(ws.cols, ws.columns)
-      XCTAssertEqual(ws.sheetPr, ws.properties)
-      XCTAssertEqual(ws.sheetFormatPr, ws.formatProperties)
-      XCTAssertEqual(
-        ws.sheetFormatPr.defaultColWidth,
-        ws.formatProperties?.defaultColumnWidth
-      )
-      XCTAssertEqual(
-        ws.sheetFormatPr.outlineLevelCol,
-        ws.formatProperties?.outlineLevelColumn
-      )
-      XCTAssertEqual(ws.dimension?.ref, ws.dimension?.reference)
-
-      guard let mcs = ws.mergeCells else {
-        XCTAssert(false, "expected to parse merge cells from categories.xlsx")
-        return
-      }
-      for mc in mcs.items {
-        XCTAssertEqual(mc.reference, mc.ref)
-      }
-
-      let allCells = ws.sheetData.rows
-        .map { $0.cells }
-        .reduce([], { $0 + $1 })
-      XCTAssertEqual(allCells.count, 90)
-
-      for r in ws.sheetData.rows {
-        XCTAssertEqual(r.height?.description, r.ht)
-      }
-
-      let rowReferences = ws.sheetData.rows.map { Int($0.reference) }
-      let cellsFromRows = try file.cellsInWorksheet(at: sheetPath,
-                                                    rows: rowReferences)
-      XCTAssertEqual(allCells, cellsFromRows)
-
-      let cellsInFirstRow = try file.cellsInWorksheet(at: sheetPath, rows: [1])
-      XCTAssertEqual(cellsInFirstRow.count, 6)
-
-      let firstColumn = ("A" as UnicodeScalar).value
-      let lastColumn = ("F" as UnicodeScalar).value
-      let columnReferences = (firstColumn...lastColumn)
-        .compactMap { UnicodeScalar($0) }.map { String($0) }
-      let cellsFromAllColumns =
-        try file.cellsInWorksheet(at: sheetPath, columns: columnReferences)
-      XCTAssertEqual(allCells, cellsFromAllColumns)
-    } catch {
-      XCTAssert(false, "unexpected error \(error)")
+  func testLegacyPublicAPI() throws {
+    guard let file =
+      XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
+      XCTAssert(false, "failed to open the file")
+      return
     }
+
+    XCTAssertEqual(try file.parseDocumentPaths(), ["xl/workbook.xml"])
+    XCTAssertEqual(try file.parseWorksheetPaths(), [sheetPath])
+
+    let relationships = try file.parseDocumentRelationships()
+    XCTAssertEqual(relationships.count, 1)
+
+    let ws = try file.parseWorksheet(at: sheetPath)
+    XCTAssertEqual(ws.cols, ws.columns)
+    XCTAssertEqual(ws.sheetPr, ws.properties)
+    XCTAssertEqual(ws.sheetFormatPr, ws.formatProperties)
+    XCTAssertEqual(
+      ws.sheetFormatPr.defaultColWidth,
+      ws.formatProperties?.defaultColumnWidth
+    )
+    XCTAssertEqual(
+      ws.sheetFormatPr.outlineLevelCol,
+      ws.formatProperties?.outlineLevelColumn
+    )
+    XCTAssertEqual(ws.dimension?.ref, ws.dimension?.reference)
+
+    guard let mcs = ws.mergeCells else {
+      XCTAssert(false, "expected to parse merge cells from categories.xlsx")
+      return
+    }
+    for mc in mcs.items {
+      XCTAssertEqual(mc.reference, mc.ref)
+    }
+
+    let allCells = ws.sheetData.rows
+      .map { $0.cells }
+      .reduce([], { $0 + $1 })
+    XCTAssertEqual(allCells.count, 90)
+
+    for r in ws.sheetData.rows {
+      XCTAssertEqual(r.height?.description, r.ht)
+    }
+
+    let rowReferences = ws.sheetData.rows.map { Int($0.reference) }
+    let cellsFromRows = try file.cellsInWorksheet(at: sheetPath,
+                                                  rows: rowReferences)
+    XCTAssertEqual(allCells, cellsFromRows)
+
+    let cellsInFirstRow = try file.cellsInWorksheet(at: sheetPath, rows: [1])
+    XCTAssertEqual(cellsInFirstRow.count, 6)
+
+    let firstColumn = ("A" as UnicodeScalar).value
+    let lastColumn = ("F" as UnicodeScalar).value
+    let columnReferences = (firstColumn...lastColumn)
+      .compactMap { UnicodeScalar($0) }.map { String($0) }
+    let cellsFromAllColumns =
+      try file.cellsInWorksheet(at: sheetPath, columns: columnReferences)
+    XCTAssertEqual(allCells, cellsFromAllColumns)
   }
 
   static let allTests = [

--- a/Tests/CoreXLSXTests/Relationships.swift
+++ b/Tests/CoreXLSXTests/Relationships.swift
@@ -54,24 +54,20 @@ final class RelationshipsTests: XCTestCase {
     decoder.keyDecodingStrategy = .convertFromCapitalized
   }
 
-  func testRelationships() {
-    do {
-      let relationships = try decoder.decode(Relationships.self,
-                                             from: exampleXML)
-      XCTAssertEqual(relationships.items, parsed)
+  func testRelationships() throws {
+    let relationships = try decoder.decode(Relationships.self,
+                                           from: exampleXML)
+    XCTAssertEqual(relationships.items, parsed)
 
-      guard let file =
-        XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
-        XCTAssert(false, "failed to open the file")
-        return
-      }
-
-      let relationshipsFromFile = try file.parseRelationships()
-
-      XCTAssertEqual(relationshipsFromFile, Relationships(items: parsed))
-    } catch {
-      XCTAssert(false, "unexpected error \(error)")
+    guard let file =
+      XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
+      XCTAssert(false, "failed to open the file")
+      return
     }
+
+    let relationshipsFromFile = try file.parseRelationships()
+
+    XCTAssertEqual(relationshipsFromFile, Relationships(items: parsed))
   }
 
   static let allTests = [

--- a/Tests/CoreXLSXTests/Relationships.swift
+++ b/Tests/CoreXLSXTests/Relationships.swift
@@ -5,26 +5,29 @@
 //  Created by Max Desiatov on 15/11/2018.
 //
 
+@testable import CoreXLSX
 import XCTest
 import XMLCoder
-@testable import CoreXLSX
 
 private let exampleXML = """
 <Relationships
 xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
 <Relationship
 Id="rId1"
-Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties"
+Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/\
+core-properties"
 Target="docProps/core.xml"/>
 
 <Relationship
 Id="rId2"
-Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties"
+Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
+extended-properties"
 Target="docProps/app.xml"/>
 
 <Relationship
 Id="rId3"
-Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
+officeDocument"
 Target="xl/workbook.xml"/>
 
 </Relationships>
@@ -59,8 +62,8 @@ final class RelationshipsTests: XCTestCase {
 
       guard let file =
         XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
-          XCTAssert(false, "failed to open the file")
-          return
+        XCTAssert(false, "failed to open the file")
+        return
       }
 
       let relationshipsFromFile = try file.parseRelationships()

--- a/Tests/CoreXLSXTests/SharedStrings.swift
+++ b/Tests/CoreXLSXTests/SharedStrings.swift
@@ -5,40 +5,38 @@
 //  Created by Max Desiatov on 30/11/2018.
 //
 
+@testable import CoreXLSX
 import XCTest
 import XMLCoder
-@testable import CoreXLSX
 
 private let parsed = SharedStrings(uniqueCount: 18, items: [
-    SharedStrings.Item(text: "Table 1", richText: nil),
-    SharedStrings.Item(text: "Item", richText: nil),
-    SharedStrings.Item(text: "Name", richText: nil),
-    SharedStrings.Item(text: "Amount", richText: nil),
-    SharedStrings.Item(text: "Name:", richText: nil),
-    SharedStrings.Item(text: "Subtotal:", richText: nil),
-    SharedStrings.Item(text: "Andy", richText: nil),
-    SharedStrings.Item(text: "Item 1", richText: nil),
-    SharedStrings.Item(text: "Item 2", richText: nil),
-    SharedStrings.Item(text: "Item 3", richText: nil),
-    SharedStrings.Item(text: "Item 4", richText: nil),
-    SharedStrings.Item(text: "Item 5", richText: nil),
-    SharedStrings.Item(text: "Chloe", richText: nil),
-    SharedStrings.Item(text: "Item 6", richText: nil),
-    SharedStrings.Item(text: "Item 7", richText: nil),
-    SharedStrings.Item(text: "Item 8", richText: nil),
-    SharedStrings.Item(text: "Item 9", richText: nil),
-    SharedStrings.Item(text: "Item 10", richText: nil),
-  ]
-)
-
+  SharedStrings.Item(text: "Table 1", richText: nil),
+  SharedStrings.Item(text: "Item", richText: nil),
+  SharedStrings.Item(text: "Name", richText: nil),
+  SharedStrings.Item(text: "Amount", richText: nil),
+  SharedStrings.Item(text: "Name:", richText: nil),
+  SharedStrings.Item(text: "Subtotal:", richText: nil),
+  SharedStrings.Item(text: "Andy", richText: nil),
+  SharedStrings.Item(text: "Item 1", richText: nil),
+  SharedStrings.Item(text: "Item 2", richText: nil),
+  SharedStrings.Item(text: "Item 3", richText: nil),
+  SharedStrings.Item(text: "Item 4", richText: nil),
+  SharedStrings.Item(text: "Item 5", richText: nil),
+  SharedStrings.Item(text: "Chloe", richText: nil),
+  SharedStrings.Item(text: "Item 6", richText: nil),
+  SharedStrings.Item(text: "Item 7", richText: nil),
+  SharedStrings.Item(text: "Item 8", richText: nil),
+  SharedStrings.Item(text: "Item 9", richText: nil),
+  SharedStrings.Item(text: "Item 10", richText: nil),
+])
 
 final class SharedStringsTests: XCTestCase {
   func testSharedStrings() {
     do {
       guard let file =
         XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
-          XCTAssert(false, "failed to open the file")
-          return
+        XCTAssert(false, "failed to open the file")
+        return
       }
 
       let sharedStrings = try file.parseSharedStrings()

--- a/Tests/CoreXLSXTests/SharedStrings.swift
+++ b/Tests/CoreXLSXTests/SharedStrings.swift
@@ -31,27 +31,23 @@ private let parsed = SharedStrings(uniqueCount: 18, items: [
 ])
 
 final class SharedStringsTests: XCTestCase {
-  func testSharedStrings() {
-    do {
-      guard let file =
-        XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
-        XCTAssert(false, "failed to open the file")
-        return
-      }
-
-      let sharedStrings = try file.parseSharedStrings()
-
-      // check each individual item so that it's easier to debug when something
-      // goes wrong
-      for (i, item) in sharedStrings.items.enumerated() {
-        XCTAssertEqual(item, parsed.items[i])
-      }
-
-      // check the complete value anyway to make sure all properties are equal
-      XCTAssertEqual(sharedStrings, parsed)
-    } catch {
-      XCTAssert(false, "unexpected error \(error)")
+  func testSharedStrings() throws {
+    guard let file =
+      XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
+      XCTAssert(false, "failed to open the file")
+      return
     }
+
+    let sharedStrings = try file.parseSharedStrings()
+
+    // check each individual item so that it's easier to debug when something
+    // goes wrong
+    for (i, item) in sharedStrings.items.enumerated() {
+      XCTAssertEqual(item, parsed.items[i])
+    }
+
+    // check the complete value anyway to make sure all properties are equal
+    XCTAssertEqual(sharedStrings, parsed)
   }
 
   static let allTests = [

--- a/Tests/CoreXLSXTests/Workbook.swift
+++ b/Tests/CoreXLSXTests/Workbook.swift
@@ -5,21 +5,21 @@
 //  Created by Max Desiatov on 23/11/2018.
 //
 
-import XCTest
 @testable import CoreXLSX
+import XCTest
 
 private let parsed = [
   Workbook.Sheet(name: "Sheet 1",
                  id: "1",
-                 relationship: "rId4")
+                 relationship: "rId4"),
 ]
 
 final class WorkbookTests: XCTestCase {
   func testWorkbook() {
     guard let file =
       XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
-        XCTAssert(false, "failed to open the file")
-        return
+      XCTAssert(false, "failed to open the file")
+      return
     }
 
     do {

--- a/Tests/CoreXLSXTests/Workbook.swift
+++ b/Tests/CoreXLSXTests/Workbook.swift
@@ -15,19 +15,15 @@ private let parsed = [
 ]
 
 final class WorkbookTests: XCTestCase {
-  func testWorkbook() {
+  func testWorkbook() throws {
     guard let file =
       XLSXFile(filepath: "\(currentWorkingPath)/categories.xlsx") else {
       XCTAssert(false, "failed to open the file")
       return
     }
 
-    do {
-      let wbs = try file.parseWorkbooks()
-      XCTAssertEqual(wbs[0].sheets.items, parsed)
-    } catch {
-      XCTAssert(false, "unexpected error \(error)")
-    }
+    let wbs = try file.parseWorkbooks()
+    XCTAssertEqual(wbs[0].sheets.items, parsed)
   }
 
   static let allTests = [

--- a/Tests/CoreXLSXTests/Worksheet.swift
+++ b/Tests/CoreXLSXTests/Worksheet.swift
@@ -135,18 +135,18 @@ private let parsed = [
 ]
 
 class WorksheetTests: XCTestCase {
-  func testExample() {
+  func testExample() throws {
     let decoder = XMLDecoder()
 
-    do {
-      let ws1 = try decoder.decode(Worksheet.self, from: xml1)
-      XCTAssertEqual(ws1.columns?.items, parsed)
-      XCTAssertEqual(ws1.cells(atRows: 1...80).count, 6)
+    let ws1 = try decoder.decode(Worksheet.self, from: xml1)
+    XCTAssertEqual(
+      ws1.formatProperties,
+      Worksheet.FormatProperties(defaultRowHeight: "15")
+    )
+    XCTAssertEqual(ws1.columns?.items, parsed)
+    XCTAssertEqual(ws1.cells(atRows: 1...80).count, 6)
 
-      let ws2 = try decoder.decode(Worksheet.self, from: xml2)
-      XCTAssertEqual(ws2.cells(atRows: 1...80).count, 5)
-    } catch {
-      XCTAssert(false, "unexpected error \(error)")
-    }
+    let ws2 = try decoder.decode(Worksheet.self, from: xml2)
+    XCTAssertEqual(ws2.cells(atRows: 1...80).count, 5)
   }
 }

--- a/Tests/CoreXLSXTests/Worksheet.swift
+++ b/Tests/CoreXLSXTests/Worksheet.swift
@@ -5,16 +5,17 @@
 //  Created by Max Desiatov on 24/11/2018.
 //
 
+@testable import CoreXLSX
 import XCTest
 import XMLCoder
-@testable import CoreXLSX
 
 private let xml1 = """
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet
   xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
   xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
-  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="x14ac"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" \
+mc:Ignorable="x14ac"
   xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac">
   <dimension ref="A1:E128"/>
   <sheetViews>
@@ -31,7 +32,8 @@ private let xml1 = """
     <col min="6" max="6" width="16" customWidth="1"/>
   </cols>
   <sheetData>
-    <row r="1" spans="1:5" s="2" customFormat="1" ht="15.75" thickBot="1" x14ac:dyDescent="0.3">
+    <row r="1" spans="1:5" s="2" customFormat="1" ht="15.75" thickBot="1" \
+x14ac:dyDescent="0.3">
       <c r="A1" s="3" t="s"/>
     </row>
     <row r="2">
@@ -62,43 +64,74 @@ private let xml1 = """
   <conditionalFormatting sqref="C2:C54">
     <cfRule type="duplicateValues" dxfId="0" priority="359"/>
   </conditionalFormatting>
-  <pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" footer="0.3"/>
+  <pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" \
+footer="0.3"/>
 </worksheet>
 """.data(using: .utf8)!
 
 private let xml2 = """
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
-<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="x14ac" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac"><dimension ref="A1:E128"/><sheetViews><sheetView tabSelected="1" workbookViewId="0"/></sheetViews><sheetFormatPr defaultRowHeight="15" x14ac:dyDescent="0.25"/><cols><col min="1" max="1" width="26.42578125" customWidth="1"/><col min="2" max="2" width="16.7109375" customWidth="1"/><col min="3" max="3" width="9.140625" style="1"/><col min="4" max="4" width="82" customWidth="1"/><col min="6" max="6" width="16" customWidth="1"/></cols><sheetData><row r=
-    "78" spans="1:5" x14ac:dyDescent="0.25"><c r="A78" t="s"><v>3</v></c><c r="B78" t="s"><v>4</v></c><c r="C78" s="1"><v>421</v></c><c r="D78" t="s"><v>56</v></c><c r="E78"><v>57</v></c></row></sheetData><conditionalFormatting sqref="C56:C1048576 C1:C54"><cfRule type="duplicateValues" dxfId="2" priority="48"/></conditionalFormatting><conditionalFormatting sqref="C1:C1048576"><cfRule type="duplicateValues" dxfId="1" priority="1"/></conditionalFormatting><conditionalFormatting sqref="C2:C54"><cfRule type="duplicateValues" dxfId="0" priority="359"/></conditionalFormatting><pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" footer="0.3"/></worksheet>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" \
+xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" \
+xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" \
+mc:Ignorable="x14ac" \
+xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac">\
+<dimension ref="A1:E128"/><sheetViews><sheetView tabSelected="1" \
+workbookViewId="0"/></sheetViews><sheetFormatPr defaultRowHeight="15" \
+x14ac:dyDescent="0.25"/><cols><col min="1" max="1" width="26.42578125" \
+customWidth="1"/><col min="2" max="2" width="16.7109375" customWidth="1"/>\
+<col min="3" max="3" width="9.140625" style="1"/><col min="4" max="4" \
+width="82" customWidth="1"/><col min="6" max="6" width="16" customWidth="1"/>\
+</cols><sheetData><row r=
+    "78" spans="1:5" x14ac:dyDescent="0.25"><c r="A78" t="s"><v>3</v></c>\
+<c r="B78" t="s"><v>4</v></c><c r="C78" s="1"><v>421</v></c><c r="D78" t="s">\
+<v>56</v></c><c r="E78"><v>57</v></c></row></sheetData><conditionalFormatting \
+sqref="C56:C1048576 C1:C54"><cfRule type="duplicateValues" dxfId="2" \
+priority="48"/></conditionalFormatting><conditionalFormatting \
+sqref="C1:C1048576"><cfRule type="duplicateValues" dxfId="1" priority="1"/>\
+</conditionalFormatting><conditionalFormatting sqref="C2:C54"><cfRule \
+type="duplicateValues" dxfId="0" priority="359"/></conditionalFormatting>\
+<pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" \
+footer="0.3"/></worksheet>
 """.data(using: .utf8)!
 
 private let parsed = [
-  Column(min: 1,
-         max: 1,
-         width: 26.42578125,
-         style: nil,
-         customWidth: true),
-  Column(min: 2,
-         max: 2,
-         width:16.7109375,
-         style: nil,
-         customWidth: true),
-  Column(min: 3,
-         max: 3,
-         width: 9.140625,
-         style: 1,
-         customWidth: nil),
-  Column(min: 4,
-         max: 4,
-         width: 82,
-         style: nil,
-         customWidth: true),
-  Column(min: 6,
-         max: 6,
-         width: 16,
-         style: nil,
-         customWidth: true),
+  Column(
+    min: 1,
+    max: 1,
+    width: 26.42578125,
+    style: nil,
+    customWidth: true
+  ),
+  Column(
+    min: 2,
+    max: 2,
+    width: 16.7109375,
+    style: nil,
+    customWidth: true
+  ),
+  Column(
+    min: 3,
+    max: 3,
+    width: 9.140625,
+    style: 1,
+    customWidth: nil
+  ),
+  Column(
+    min: 4,
+    max: 4,
+    width: 82,
+    style: nil,
+    customWidth: true
+  ),
+  Column(
+    min: 6,
+    max: 6,
+    width: 16,
+    style: nil,
+    customWidth: true
+  ),
 ]
 
 class WorksheetTests: XCTestCase {


### PR DESCRIPTION
This fixes some of the errors thrown by the file attached in #41. Support for XML namespaces which that file uses for worksheet data will be resolved in a separate PR.