### PR TITLE
missing `text` property when format is applied at the character level

### DIFF
--- a/Sources/CoreXLSX/SharedStrings.swift
+++ b/Sources/CoreXLSX/SharedStrings.swift
@@ -84,8 +84,10 @@ public struct RichText: Codable, Equatable {
   }
 
   public let properties: Properties?
+  public let text: String?
 
   enum CodingKeys: String, CodingKey {
     case properties = "rPr"
+    case text = "t"
   }
 }

--- a/Tests/CoreXLSXTests/SharedStrings.swift
+++ b/Tests/CoreXLSXTests/SharedStrings.swift
@@ -131,15 +131,15 @@ final class SharedStringsTests: XCTestCase {
   func testRichTextXML() throws {
     let decoder = XMLDecoder()
     let strings = try decoder.decode(SharedStrings.self, from: richTextXML)
-    let text = strings.items[1].richText.reduce("", {(t, rt) -> String  in
-      return t + (rt.text ?? "")
-      })
+    let text = strings.items[1].richText.reduce("") { (t, rt) -> String in
+      t + (rt.text ?? "")
+    }
     XCTAssertEqual(text, "CellA2")
   }
 
   static let allTests = [
     ("testSharedStrings", testSharedStrings),
     ("testSharedStringsOrder", testSharedStringsOrder),
-    ("testSharedStringsRichText", testRichTextXML)
+    ("testSharedStringsRichText", testRichTextXML),
   ]
 }

--- a/Tests/CoreXLSXTests/SharedStrings.swift
+++ b/Tests/CoreXLSXTests/SharedStrings.swift
@@ -48,6 +48,38 @@ private let spacePreserveXML = """
 </sst>
 """.data(using: .utf8)!
 
+
+private let richTextXML = """
+<sst uniqueCount="2">
+  <si>
+    <t>My Cell</t>
+  </si>
+  <si>
+    <r>
+      <rPr>
+        <sz val="11"/>
+        <color rgb="FFFF0000"/>
+        <rFont val="Calibri"/>
+        <family val="2"/>
+        <scheme val="minor"/>
+      </rPr>
+      <t>Cell</t>
+    </r>
+    <r>
+      <rPr>
+        <b/>
+        <sz val="11"/>
+        <color theme="1"/>
+        <rFont val="Calibri"/>
+        <family val="2"/>
+        <scheme val="minor"/>
+      </rPr>
+      <t>A2</t>
+    </r>
+  </si>
+</sst>
+""".data(using: .utf8)!
+
 final class SharedStringsTests: XCTestCase {
   func testSharedStrings() throws {
     guard let file =
@@ -96,9 +128,19 @@ final class SharedStringsTests: XCTestCase {
     let strings = try decoder.decode(SharedStrings.self, from: spacePreserveXML)
     XCTAssertEqual(strings.items.count, 1)
   }
+  
+  func testRichTextXML() throws {
+    let decoder = XMLDecoder()
+    let strings = try decoder.decode(SharedStrings.self, from: richTextXML)
+    let text = strings.items[1].richText.reduce("", {(t, rt) -> String  in
+      return t + (rt.text ?? "")
+      })
+    XCTAssertEqual(text, "CellA2")
+  }
 
   static let allTests = [
     ("testSharedStrings", testSharedStrings),
     ("testSharedStringsOrder", testSharedStringsOrder),
+    ("testSharedStringsRichText", testRichTextXML)
   ]
 }

--- a/Tests/CoreXLSXTests/SharedStrings.swift
+++ b/Tests/CoreXLSXTests/SharedStrings.swift
@@ -48,7 +48,6 @@ private let spacePreserveXML = """
 </sst>
 """.data(using: .utf8)!
 
-
 private let richTextXML = """
 <sst uniqueCount="2">
   <si>
@@ -128,7 +127,7 @@ final class SharedStringsTests: XCTestCase {
     let strings = try decoder.decode(SharedStrings.self, from: spacePreserveXML)
     XCTAssertEqual(strings.items.count, 1)
   }
-  
+
   func testRichTextXML() throws {
     let decoder = XMLDecoder()
     let strings = try decoder.decode(SharedStrings.self, from: richTextXML)


### PR DESCRIPTION
There should be a `<t>` tag when format is applied at the character level; Follow the [reference](https://docs.microsoft.com/en-us/office/open-xml/working-with-the-shared-string-table)
