### PR TITLE
Fix non-macOS framework targets

### DIFF
--- a/CoreXLSX.xcodeproj/project.pbxproj
+++ b/CoreXLSX.xcodeproj/project.pbxproj
@@ -37,6 +37,9 @@
 		D150221321A1D97E00BFA4FC /* CoreXLSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* CoreXLSX.swift */; };
 		D150221421A1D97E00BFA4FC /* Relationships.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* Relationships.swift */; };
 		D150221521A1D97E00BFA4FC /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Worksheet.swift */; };
+		D15C747322CB459C0041320B /* Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AAB1C722A154A800C30F99 /* Comments.swift */; };
+		D15C747422CB459C0041320B /* Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AAB1C722A154A800C30F99 /* Comments.swift */; };
+		D15C747522CB459D0041320B /* Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AAB1C722A154A800C30F99 /* Comments.swift */; };
 		D1769CCC225F456A00521A47 /* Namespaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1769CCA225F456300521A47 /* Namespaces.swift */; };
 		D1A8190921A9CB89004FCA33 /* Worksheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A8190821A9CB89004FCA33 /* Worksheet.swift */; };
 		D1A8190B21A9D0EF004FCA33 /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A8190A21A9D0EF004FCA33 /* Cell.swift */; };
@@ -667,6 +670,7 @@
 				D15021E221A1CB0500BFA4FC /* Relationships.swift in Sources */,
 				D15021E321A1CB0500BFA4FC /* Worksheet.swift in Sources */,
 				D1EB9C6C21A98FFE002F2254 /* Workbook.swift in Sources */,
+				D15C747322CB459C0041320B /* Comments.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -685,6 +689,7 @@
 				D15021FE21A1D1DB00BFA4FC /* Relationships.swift in Sources */,
 				D15021FF21A1D1DB00BFA4FC /* Worksheet.swift in Sources */,
 				D1EB9C6D21A98FFE002F2254 /* Workbook.swift in Sources */,
+				D15C747422CB459C0041320B /* Comments.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -703,6 +708,7 @@
 				D150221421A1D97E00BFA4FC /* Relationships.swift in Sources */,
 				D150221521A1D97E00BFA4FC /* Worksheet.swift in Sources */,
 				D1EB9C6E21A98FFE002F2254 /* Workbook.swift in Sources */,
+				D15C747522CB459D0041320B /* Comments.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/test_swiftpm.sh
+++ b/test_swiftpm.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+set -e 
+set -o pipefail
+
 TESTS_PATH=$PWD/Tests/CoreXLSXTests swift test

--- a/test_xcodebuild.sh
+++ b/test_xcodebuild.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 
+set -e 
+set -o pipefail
+
 sudo xcode-select --switch /Applications/$1.app/Contents/Developer
 
 xcodebuild -version
 carthage bootstrap
-set -o pipefail && xcodebuild build -scheme CoreXLSXiOS \
+xcodebuild build -scheme CoreXLSXiOS \
   -sdk iphonesimulator -destination "$IOS_DEVICE" | xcpretty
-set -o pipefail && xcodebuild build -scheme CoreXLSXtvOS \
+xcodebuild build -scheme CoreXLSXtvOS \
   -sdk appletvsimulator -destination "$TVOS_DEVICE" | xcpretty
 
 if [ -n "$CODECOV_JOB" ]; then
-  set -o pipefail && xcodebuild test -enableCodeCoverage YES -scheme CoreXLSX \
+  xcodebuild test -enableCodeCoverage YES -scheme CoreXLSX \
     -sdk macosx | xcpretty
   bash <(curl -s https://codecov.io/bash)
 else 
-  set -o pipefail && xcodebuild test -scheme CoreXLSX \
+  xcodebuild test -scheme CoreXLSX \
     -sdk macosx | xcpretty
 fi


### PR DESCRIPTION
All of these targets are failing due to `Comments.swift` file not added to all targets. CI still passes though as `pipefail` isn't applied to all script commands.