### PR TITLE
Bump XMLCoder dependency to 0.8.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "weichsel/ZIPFoundation" ~> 0.9.9
-github "MaxDesiatov/XMLCoder" ~> 0.7.0
+github "MaxDesiatov/XMLCoder" ~> 0.8.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "MaxDesiatov/XMLCoder" "0.7.0"
+github "MaxDesiatov/XMLCoder" "0.8.0"
 github "weichsel/ZIPFoundation" "0.9.9"

--- a/CoreXLSX.podspec
+++ b/CoreXLSX.podspec
@@ -43,5 +43,5 @@ Excel spreadsheet (XLSX) format support in pure Swift.
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
   s.dependency 'ZIPFoundation', '~> 0.9.9'
-  s.dependency 'XMLCoder', '~> 0.7.0'
+  s.dependency 'XMLCoder', '~> 0.8.0'
 end

--- a/CoreXLSX.podspec
+++ b/CoreXLSX.podspec
@@ -27,7 +27,6 @@ Excel spreadsheet (XLSX) format support in pure Swift.
   s.license          = { :type => 'Apache 2.0', :file => 'LICENSE.md' }
   s.author           = { 'Max Desiatov' => 'max@desiatov.com' }
   s.source           = { :git => 'https://github.com/MaxDesiatov/CoreXLSX.git', :tag => s.version.to_s }
-  s.social_media_url = 'https://twitter.com/MaxDesiatov'
 
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - CoreXLSX (0.7.0):
-    - XMLCoder (~> 0.7.0)
+  - CoreXLSX (0.8.0):
+    - XMLCoder (~> 0.8.0)
     - ZIPFoundation (~> 0.9.9)
-  - XMLCoder (0.7.0)
+  - XMLCoder (0.8.0)
   - ZIPFoundation (0.9.9)
 
 DEPENDENCIES:
@@ -18,10 +18,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CoreXLSX: 64caee692b02dbf0b4feb351fcb2b884a7219bbb
-  XMLCoder: 6c31ac37631628912c5afe51adce692b5748841f
+  CoreXLSX: 45a3d8a8b957b9c03055f5fa4705586e5d2500e3
+  XMLCoder: fd2998fcc6195f613e570597d18d789b95a19297
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
 PODFILE CHECKSUM: 4b59cda9563eaa9d39027ba3749963cf8b4676e7
 
-COCOAPODS: 1.7.3
+COCOAPODS: 1.7.5

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/maxdesiatov/XMLCoder.git",
         "state": {
           "branch": null,
-          "revision": "06295cb8a9670937627a68b1876a201609739c97",
-          "version": "0.7.0"
+          "revision": "f68964b14c34f73f2a6fa56f30d8a355e21afc25",
+          "version": "0.8.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
     .package(url: "https://github.com/maxdesiatov/XMLCoder.git",
-             .upToNextMajor(from: "0.7.0")),
+             .upToNextMajor(from: "0.8.0")),
     .package(url: "https://github.com/weichsel/ZIPFoundation.git",
              .upToNextMajor(from: "0.9.9")),
   ],

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -18,7 +18,7 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
     .package(url: "https://github.com/maxdesiatov/XMLCoder.git",
-             .upToNextMajor(from: "0.7.0")),
+             .upToNextMajor(from: "0.8.0")),
     .package(url: "https://github.com/weichsel/ZIPFoundation.git",
              .upToNextMajor(from: "0.9.9")),
   ],


### PR DESCRIPTION
Looks like 404 checks reported by `pod lib lint` are triggered by `social_media_url` in the podspec, this is now removed to make the checks pass.