### PR TITLE
Bump line length limit in .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,8 +7,8 @@ disabled_rules:
 - cyclomatic_complexity
 
 line_length:
-- 80
 - 100
+- 120
 
 function_body_length:
 - 50

--- a/pod.sh
+++ b/pod.sh
@@ -3,5 +3,5 @@
 set -e 
 set -o pipefail
 
-pod repo update
+cd Example && pod install --repo-update && cd ..
 pod lib lint --verbose


### PR DESCRIPTION
Also, work around CocoaPods CI job issues.