### PR TITLE
Update ZIPFoundation to 0.9.10

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "weichsel/ZIPFoundation" ~> 0.9.9
+github "weichsel/ZIPFoundation" ~> 0.9.10
 github "MaxDesiatov/XMLCoder" ~> 0.9.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "MaxDesiatov/XMLCoder" "0.9.0"
-github "weichsel/ZIPFoundation" "0.9.9"
+github "weichsel/ZIPFoundation" "0.9.10"

--- a/CoreXLSX.podspec
+++ b/CoreXLSX.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 #   * Write the description between the DESC delimiters below.
 #   * Finally, don't worry about the indent, CocoaPods strips it!
 
-  s.swift_versions    = ['4.2', '5.0', '5.1']
+  s.swift_versions    = ['4.2', '5.0', '5.1', '5.2']
   s.description      = <<-DESC
 Excel spreadsheet (XLSX) format support in pure Swift.
                        DESC
@@ -41,6 +41,6 @@ Excel spreadsheet (XLSX) format support in pure Swift.
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
-  s.dependency 'ZIPFoundation', '~> 0.9.9'
+  s.dependency 'ZIPFoundation', '~> 0.9.10'
   s.dependency 'XMLCoder', '~> 0.9.0'
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
   - CoreXLSX (0.9.1):
     - XMLCoder (~> 0.9.0)
-    - ZIPFoundation (~> 0.9.9)
+    - ZIPFoundation (~> 0.9.10)
   - XMLCoder (0.9.0)
-  - ZIPFoundation (0.9.9)
+  - ZIPFoundation (0.9.10)
 
 DEPENDENCIES:
   - CoreXLSX (from `../`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - XMLCoder
     - ZIPFoundation
 
@@ -18,10 +18,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CoreXLSX: b544bca9aaa808b7dede5dab3fa4524dac7ba943
+  CoreXLSX: 4636a7197b2118421d632c43fd72df46ad9562b0
   XMLCoder: f812facc69ac5fb5f4af9f970a9154ad0b614014
-  ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
+  ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
 PODFILE CHECKSUM: 4b59cda9563eaa9d39027ba3749963cf8b4676e7
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.9.0

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/weichsel/ZIPFoundation.git",
         "state": {
           "branch": null,
-          "revision": "edbeaa39b426e54702194b0a601342322f01e400",
-          "version": "0.9.9"
+          "revision": "3f38d518c5e41f1cf25ff6a1d28c46db5e79a0b9",
+          "version": "0.9.10"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     .package(url: "https://github.com/maxdesiatov/XMLCoder.git",
              .upToNextMajor(from: "0.9.0")),
     .package(url: "https://github.com/weichsel/ZIPFoundation.git",
-             .upToNextMajor(from: "0.9.9")),
+             .upToNextMajor(from: "0.9.10")),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -20,7 +20,7 @@ let package = Package(
     .package(url: "https://github.com/maxdesiatov/XMLCoder.git",
              .upToNextMajor(from: "0.9.0")),
     .package(url: "https://github.com/weichsel/ZIPFoundation.git",
-             .upToNextMajor(from: "0.9.9")),
+             .upToNextMajor(from: "0.9.10")),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define


### PR DESCRIPTION
Notable updates in the new version:

>   * Fixed a race condition during archive creation or extraction
>   * Fixed an error when trying to add broken symlinks to an archive
>   * Fixed an App Store submission issue by updating the product identifier to use reverse DNS notation
>   * Improved CRC32 calculation performance
>   * Improved entry replacement performance on separate volumes
>   * Improved documentation for closure-based writing