### PR TITLE
Fix workbooks with no views, cleanup tests

### DIFF
--- a/Sources/CoreXLSX/Workbook.swift
+++ b/Sources/CoreXLSX/Workbook.swift
@@ -21,7 +21,7 @@ public struct Workbook: Codable, Equatable {
     public let windowHeight: UInt
   }
 
-  public let views: Views
+  public let views: Views?
 
   public struct Sheets: Codable, Equatable {
     public let items: [Sheet]

--- a/Tests/CoreXLSXTests/CellReference.swift
+++ b/Tests/CoreXLSXTests/CellReference.swift
@@ -22,10 +22,10 @@ private let exampleXML3 = """
 """.data(using: .utf8)!
 
 final class CellReferenceTests: XCTestCase {
-  private let decoder = XMLDecoder()
-  private let encoder = XMLEncoder()
-
   func testCellReference() throws {
+    let decoder = XMLDecoder()
+    let encoder = XMLEncoder()
+
     let c1 = try decoder.decode(Cell.self, from: exampleXML1)
     let cr1 = CellReference(ColumnReference("A")!, 7)
     XCTAssertEqual(cr1.description, "A7")
@@ -144,12 +144,4 @@ final class CellReferenceTests: XCTestCase {
 
     XCTAssertEqual((a...bz).reversed().reversed(), Array(a...bz))
   }
-
-  static let allTests = [
-    ("testColumnReference", testColumnReference),
-    ("testCellReference", testCellReference),
-    ("testColumnReferenceDistance", testColumnReferenceDistance),
-    ("testColumnReferenceStringInitializerPerformance",
-     testColumnReferenceStringInitializerPerformance),
-  ]
 }

--- a/Tests/CoreXLSXTests/CoreXLSX.swift
+++ b/Tests/CoreXLSXTests/CoreXLSX.swift
@@ -174,9 +174,4 @@ final class CoreXLSXTests: XCTestCase {
       try file.cellsInWorksheet(at: sheetPath, columns: columnReferences)
     XCTAssertEqual(allCells, cellsFromAllColumns)
   }
-
-  static let allTests = [
-    ("testPublicAPI", testPublicAPI),
-    ("testLegacyPublicAPI", testLegacyPublicAPI),
-  ]
 }

--- a/Tests/CoreXLSXTests/Formula.swift
+++ b/Tests/CoreXLSXTests/Formula.swift
@@ -34,9 +34,8 @@ private let formulaXML = """
 """.data(using: .utf8)!
 
 final class FormulaTests: XCTestCase {
-  private let decoder = XMLDecoder()
-
   func testFormulas() throws {
+    let decoder = XMLDecoder()
     decoder.shouldProcessNamespaces = true
 
     let row = try decoder.decode(Row.self, from: formulaXML)

--- a/Tests/CoreXLSXTests/Namespaces.swift
+++ b/Tests/CoreXLSXTests/Namespaces.swift
@@ -131,9 +131,8 @@ xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
 """.data(using: .utf8)!
 
 final class NamespacesTests: XCTestCase {
-  private let decoder = XMLDecoder()
-
   func testNamespaces() throws {
+    let decoder = XMLDecoder()
     decoder.shouldProcessNamespaces = true
 
     let worksheet = try decoder.decode(Worksheet.self, from: namespaceXML)

--- a/Tests/CoreXLSXTests/Relationships.swift
+++ b/Tests/CoreXLSXTests/Relationships.swift
@@ -46,15 +46,9 @@ private let parsed = [
 ]
 
 final class RelationshipsTests: XCTestCase {
-  private let decoder = XMLDecoder()
-
-  override func setUp() {
-    super.setUp()
-
-    decoder.keyDecodingStrategy = .convertFromCapitalized
-  }
-
   func testRelationships() throws {
+    let decoder = XMLDecoder()
+    decoder.keyDecodingStrategy = .convertFromCapitalized
     let relationships = try decoder.decode(Relationships.self,
                                            from: exampleXML)
     XCTAssertEqual(relationships.items, parsed)
@@ -91,8 +85,4 @@ final class RelationshipsTests: XCTestCase {
     let paths = try file.parseWorksheetPaths()
     XCTAssertEqual(paths, ["xl/worksheets/sheet1.xml"])
   }
-
-  static let allTests = [
-    ("testRelationships", testRelationships),
-  ]
 }

--- a/Tests/CoreXLSXTests/Workbook.swift
+++ b/Tests/CoreXLSXTests/Workbook.swift
@@ -7,12 +7,35 @@
 
 @testable import CoreXLSX
 import XCTest
+import XMLCoder
 
-private let parsed = [
+private let parsedSheet = [
   Workbook.Sheet(name: "Sheet 1",
                  id: "1",
                  relationship: "rId4"),
 ]
+
+// swiftlint:disable line_length
+private let workbookNoViews =
+  """
+  <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+  <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mx="http://schemas.microsoft.com/office/mac/excel/2008/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mv="urn:schemas-microsoft-com:mac:vml" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" xmlns:x15="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main"><workbookPr/><sheets><sheet state="visible" name="Summary" sheetId="1" r:id="rId4"/><sheet state="visible" name="General" sheetId="2" r:id="rId5"/></sheets><definedNames/><calcPr/></workbook>
+  """.data(using: .utf8)!
+// swiftlint:enable line_length
+
+private let expectedWorkbook =
+  Workbook(views: nil, sheets: .init(items: [
+    .init(
+      name: "Summary",
+      id: "1",
+      relationship: "rId4"
+    ),
+    .init(
+      name: "General",
+      id: "2",
+      relationship: "rId5"
+    ),
+  ]))
 
 final class WorkbookTests: XCTestCase {
   func testWorkbook() throws {
@@ -23,10 +46,15 @@ final class WorkbookTests: XCTestCase {
     }
 
     let wbs = try file.parseWorkbooks()
-    XCTAssertEqual(wbs[0].sheets.items, parsed)
+    XCTAssertEqual(wbs[0].sheets.items, parsedSheet)
   }
 
-  static let allTests = [
-    ("testWorkbook", testWorkbook),
-  ]
+  func testWorkbookNoViews() throws {
+    let decoder = XMLDecoder()
+    decoder.shouldProcessNamespaces = true
+
+    let decoded = try decoder.decode(Workbook.self, from: workbookNoViews)
+
+    XCTAssertEqual(decoded, expectedWorkbook)
+  }
 }

--- a/Tests/CoreXLSXTests/XCTestManifests.swift
+++ b/Tests/CoreXLSXTests/XCTestManifests.swift
@@ -70,6 +70,7 @@ extension RelationshipsTests {
   //   `swift test --generate-linuxmain`
   // to regenerate.
   static let __allTests__RelationshipsTests = [
+    ("testCustomXmlSchemaType", testCustomXmlSchemaType),
     ("testRelationships", testRelationships),
   ]
 }
@@ -101,6 +102,7 @@ extension WorkbookTests {
   // to regenerate.
   static let __allTests__WorkbookTests = [
     ("testWorkbook", testWorkbook),
+    ("testWorkbookNoViews", testWorkbookNoViews),
   ]
 }
 


### PR DESCRIPTION
Fix reported test case, regenerate Linux tests, make tests more friendly towards parallel runs by avoiding sharing decoder instances.