### PR TITLE
officeDocument is misspelled in corePropreties Relationship

### DIFF
--- a/Sources/CoreXLSX/Relationships.swift
+++ b/Sources/CoreXLSX/Relationships.swift
@@ -37,7 +37,7 @@ public struct Relationship: Codable, Equatable {
       """
     case coreProperties =
       """
-      http://schemas.openxmlformats.org/officedocument/2006/relationships/\
+      http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
       metadata/core-properties
       """
     case connections =


### PR DESCRIPTION
http://schemas.openxmlformats.org/officeDocument/2006/relationships/\
      metadata/core-properties

in Relationships.swift officeDocument was written lowercase which caused a crash when reading file.parseWorksheetPaths()