### PR TITLE
Fix for: Cannot initialize SchemaType from invalid String value http:…

### DIFF
--- a/Sources/CoreXLSX/Relationships.swift
+++ b/Sources/CoreXLSX/Relationships.swift
@@ -130,6 +130,10 @@ public struct Relationship: Codable, Equatable {
       """
       http://purl.oclc.org/ooxml/officeDocument/relationships/extendedProperties
       """
+    case sheetMetadata =
+      """
+      http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata
+      """
   }
 
   /// The identifier for this entity.


### PR DESCRIPTION
Fix for error:

> dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "relationship", intValue: nil), XMLKey(stringValue: "4", intValue: 4), XMLKey(stringValue: "4", intValue: 4), CodingKeys(stringValue: "type", intValue: nil)], debugDescription: "Cannot initialize SchemaType from invalid String value http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata", underlyingError: nil))

Reproduced after converted a fairly complex .numbers file to .xlsx